### PR TITLE
feat: add explicit content filter for Deezer tracks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ DEEZER_ARL_FALLBACK=
 # Preferred audio quality: FLAC, MP3_320, MP3_128 (optional)
 # If not specified, the highest available quality for your account will be used
 DEEZER_QUALITY=
+
+# Explicit content filter (optional, default: All)
+# - All: Show all tracks (no filtering)
+# - ExplicitOnly: Exclude clean/edited versions, keep original explicit content
+# - CleanOnly: Only show clean content (naturally clean or edited versions)
+EXPLICIT_FILTER=All

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       # Navidrome/Subsonic server URL
       - Subsonic__Url=${SUBSONIC_URL:-http://localhost:4533}
+      # Explicit content filter: All, ExplicitOnly, CleanOnly (default: ExplicitOnly)
+      - Subsonic__ExplicitFilter=${EXPLICIT_FILTER:-ExplicitOnly}
       # Download path inside container
       - Library__DownloadPath=/app/downloads
       # Deezer ARL token (required)

--- a/octo-fiesta/Models/MusicModels.cs
+++ b/octo-fiesta/Models/MusicModels.cs
@@ -88,6 +88,12 @@ public class Song
     /// Local file path (if available)
     /// </summary>
     public string? LocalPath { get; set; }
+    
+    /// <summary>
+    /// Deezer explicit content lyrics value
+    /// 0 = Naturally clean, 1 = Explicit, 2 = Not applicable, 3 = Clean/edited version, 6/7 = Unknown
+    /// </summary>
+    public int? ExplicitContentLyrics { get; set; }
 }
 
 /// <summary>

--- a/octo-fiesta/Models/SubsonicSettings.cs
+++ b/octo-fiesta/Models/SubsonicSettings.cs
@@ -1,6 +1,36 @@
-﻿namespace octo_fiesta.Models;
+namespace octo_fiesta.Models;
+
+/// <summary>
+/// Explicit content filter mode for Deezer tracks
+/// </summary>
+public enum ExplicitFilter
+{
+    /// <summary>
+    /// Show all tracks (no filtering)
+    /// </summary>
+    All,
+    
+    /// <summary>
+    /// Exclude clean/edited versions (explicit_content_lyrics == 3)
+    /// Shows original explicit content and naturally clean content
+    /// </summary>
+    ExplicitOnly,
+    
+    /// <summary>
+    /// Only show clean content (explicit_content_lyrics == 0 or 3)
+    /// Excludes tracks with explicit_content_lyrics == 1
+    /// </summary>
+    CleanOnly
+}
 
 public class SubsonicSettings
 {
-        public string? Url { get; set; }
+    public string? Url { get; set; }
+    
+    /// <summary>
+    /// Explicit content filter mode (default: All)
+    /// Environment variable: EXPLICIT_FILTER
+    /// Values: "All", "ExplicitOnly", "CleanOnly"
+    /// </summary>
+    public ExplicitFilter ExplicitFilter { get; set; } = ExplicitFilter.All;
 }

--- a/octo-fiesta/Services/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/DeezerMetadataService.cs
@@ -1,5 +1,6 @@
 using octo_fiesta.Models;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 
 namespace octo_fiesta.Services;
 
@@ -9,11 +10,13 @@ namespace octo_fiesta.Services;
 public class DeezerMetadataService : IMusicMetadataService
 {
     private readonly HttpClient _httpClient;
+    private readonly SubsonicSettings _settings;
     private const string BaseUrl = "https://api.deezer.com";
 
-    public DeezerMetadataService(IHttpClientFactory httpClientFactory)
+    public DeezerMetadataService(IHttpClientFactory httpClientFactory, IOptions<SubsonicSettings> settings)
     {
         _httpClient = httpClientFactory.CreateClient();
+        _settings = settings.Value;
     }
 
     public async Task<List<Song>> SearchSongsAsync(string query, int limit = 20)
@@ -33,7 +36,11 @@ public class DeezerMetadataService : IMusicMetadataService
             {
                 foreach (var track in data.EnumerateArray())
                 {
-                    songs.Add(ParseDeezerTrack(track));
+                    var song = ParseDeezerTrack(track);
+                    if (ShouldIncludeSong(song))
+                    {
+                        songs.Add(song);
+                    }
                 }
             }
             
@@ -219,7 +226,11 @@ public class DeezerMetadataService : IMusicMetadataService
             foreach (var track in tracksData.EnumerateArray())
             {
                 // Pass the index as fallback for track_position (Deezer doesn't include it in album tracks)
-                album.Songs.Add(ParseDeezerTrack(track, trackIndex));
+                var song = ParseDeezerTrack(track, trackIndex);
+                if (ShouldIncludeSong(song))
+                {
+                    album.Songs.Add(song);
+                }
                 trackIndex++;
             }
         }
@@ -277,6 +288,11 @@ public class DeezerMetadataService : IMusicMetadataService
             ? trackPos.GetInt32() 
             : fallbackTrackNumber;
         
+        // Explicit content lyrics value
+        int? explicitContentLyrics = track.TryGetProperty("explicit_content_lyrics", out var ecl) 
+            ? ecl.GetInt32() 
+            : null;
+        
         return new Song
         {
             Id = $"ext-deezer-song-{externalId}",
@@ -303,7 +319,8 @@ public class DeezerMetadataService : IMusicMetadataService
                 : null,
             IsLocal = false,
             ExternalProvider = "deezer",
-            ExternalId = externalId
+            ExternalId = externalId,
+            ExplicitContentLyrics = explicitContentLyrics
         };
     }
 
@@ -394,6 +411,11 @@ public class DeezerMetadataService : IMusicMetadataService
                 : (albumForCover.TryGetProperty("cover_big", out var cb) ? cb.GetString() : null);
         }
         
+        // Explicit content lyrics value
+        int? explicitContentLyrics = track.TryGetProperty("explicit_content_lyrics", out var ecl) 
+            ? ecl.GetInt32() 
+            : null;
+        
         return new Song
         {
             Id = $"ext-deezer-song-{externalId}",
@@ -425,7 +447,8 @@ public class DeezerMetadataService : IMusicMetadataService
             CoverArtUrlLarge = coverLarge,
             IsLocal = false,
             ExternalProvider = "deezer",
-            ExternalId = externalId
+            ExternalId = externalId,
+            ExplicitContentLyrics = explicitContentLyrics
         };
     }
 
@@ -480,6 +503,35 @@ public class DeezerMetadataService : IMusicMetadataService
             IsLocal = false,
             ExternalProvider = "deezer",
             ExternalId = externalId
+        };
+    }
+
+    /// <summary>
+    /// Determines whether a song should be included based on the explicit content filter setting
+    /// </summary>
+    /// <param name="song">The song to check</param>
+    /// <returns>True if the song should be included, false otherwise</returns>
+    private bool ShouldIncludeSong(Song song)
+    {
+        // If no explicit content info, include the song
+        if (song.ExplicitContentLyrics == null)
+            return true;
+        
+        return _settings.ExplicitFilter switch
+        {
+            // All: No filtering, include everything
+            ExplicitFilter.All => true,
+            
+            // ExplicitOnly: Exclude clean/edited versions (value 3)
+            // Include: 0 (naturally clean), 1 (explicit), 2 (not applicable), 6/7 (unknown)
+            ExplicitFilter.ExplicitOnly => song.ExplicitContentLyrics != 3,
+            
+            // CleanOnly: Only show clean content
+            // Include: 0 (naturally clean), 3 (clean/edited version)
+            // Exclude: 1 (explicit)
+            ExplicitFilter.CleanOnly => song.ExplicitContentLyrics != 1,
+            
+            _ => true
         };
     }
 }

--- a/octo-fiesta/appsettings.json
+++ b/octo-fiesta/appsettings.json
@@ -7,7 +7,8 @@
   },
   "AllowedHosts": "*",
   "Subsonic": {
-    "Url": "http://localhost:4533"
+    "Url": "http://localhost:4533",
+    "ExplicitFilter": "All"
   },
   "Library": {
     "DownloadPath": "./downloads"


### PR DESCRIPTION
## Summary

Adds an `EXPLICIT_FILTER` environment variable to control which Deezer tracks are shown based on their explicit content metadata.

## Options

| Value | Behavior |
|-------|----------|
| `All` (default) | No filtering - shows all tracks |
| `ExplicitOnly` | Excludes clean/radio edit versions (keeps original explicit content) |
| `CleanOnly` | Only shows clean content (excludes explicit tracks) |

## Technical Details

- Filters based on Deezer's `explicit_content_lyrics` field
- Applied to search results and album track listings
- Direct access by ID is not filtered (intentional)

## Testing

- 6 new unit tests covering all filter modes
- Manual testing verified filtering works correctly

Closes #22