### PR TITLE
feat: add download mode option (Track/Album) for Deezer downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ DEEZER_QUALITY=
 # - ExplicitOnly: Exclude clean/edited versions, keep original explicit content
 # - CleanOnly: Only show clean content (naturally clean or edited versions)
 EXPLICIT_FILTER=All
+
+# Download mode (optional, default: Track)
+# - Track: Download only the played track
+# - Album: When playing a track, download the entire album in background
+#          The played track is downloaded first, remaining tracks are queued
+DOWNLOAD_MODE=Track

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - Subsonic__Url=${SUBSONIC_URL:-http://localhost:4533}
       # Explicit content filter: All, ExplicitOnly, CleanOnly (default: ExplicitOnly)
       - Subsonic__ExplicitFilter=${EXPLICIT_FILTER:-ExplicitOnly}
+      # Download mode: Track (only requested track), Album (full album when playing a track)
+      - Subsonic__DownloadMode=${DOWNLOAD_MODE:-Track}
       # Download path inside container
       - Library__DownloadPath=/app/downloads
       # Deezer ARL token (required)

--- a/octo-fiesta/Models/SubsonicSettings.cs
+++ b/octo-fiesta/Models/SubsonicSettings.cs
@@ -1,6 +1,23 @@
 namespace octo_fiesta.Models;
 
 /// <summary>
+/// Download mode for tracks
+/// </summary>
+public enum DownloadMode
+{
+    /// <summary>
+    /// Download only the requested track (default behavior)
+    /// </summary>
+    Track,
+    
+    /// <summary>
+    /// When a track is played, download the entire album in background
+    /// The requested track is downloaded first, then remaining tracks are queued
+    /// </summary>
+    Album
+}
+
+/// <summary>
 /// Explicit content filter mode for Deezer tracks
 /// </summary>
 public enum ExplicitFilter
@@ -33,4 +50,11 @@ public class SubsonicSettings
     /// Values: "All", "ExplicitOnly", "CleanOnly"
     /// </summary>
     public ExplicitFilter ExplicitFilter { get; set; } = ExplicitFilter.All;
+    
+    /// <summary>
+    /// Download mode for tracks (default: Track)
+    /// Environment variable: DOWNLOAD_MODE
+    /// Values: "Track" (download only played track), "Album" (download full album when playing a track)
+    /// </summary>
+    public DownloadMode DownloadMode { get; set; } = DownloadMode.Track;
 }

--- a/octo-fiesta/Services/IDownloadService.cs
+++ b/octo-fiesta/Services/IDownloadService.cs
@@ -26,6 +26,14 @@ public interface IDownloadService
     Task<Stream> DownloadAndStreamAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
     
     /// <summary>
+    /// Downloads remaining tracks from an album in background (excluding the specified track)
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, spotify)</param>
+    /// <param name="albumExternalId">The album ID on the external provider</param>
+    /// <param name="excludeTrackExternalId">The track ID to exclude (already downloaded)</param>
+    void DownloadRemainingAlbumTracksInBackground(string externalProvider, string albumExternalId, string excludeTrackExternalId);
+    
+    /// <summary>
     /// Checks if a song is currently being downloaded
     /// </summary>
     DownloadInfo? GetDownloadStatus(string songId);

--- a/octo-fiesta/appsettings.json
+++ b/octo-fiesta/appsettings.json
@@ -8,7 +8,8 @@
   "AllowedHosts": "*",
   "Subsonic": {
     "Url": "http://localhost:4533",
-    "ExplicitFilter": "All"
+    "ExplicitFilter": "All",
+    "DownloadMode": "Track"
   },
   "Library": {
     "DownloadPath": "./downloads"


### PR DESCRIPTION
## Summary
- Add configurable download mode: `Track` (default) downloads only the played track, `Album` downloads the entire album in background when a track is played
- The played track is prioritized and streamed immediately, remaining album tracks are queued for background download

Closes #10