### PR TITLE
feat: add SquidWTF music provider with Qobuz/Tidal backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ SUBSONIC_URL=http://localhost:4533
 # Path where downloaded songs will be stored on the host (only applies if STORAGE_MODE=Permanent)
 DOWNLOAD_PATH=./downloads
 
-# Music service to use: Deezer or Qobuz (default: Deezer)
-MUSIC_SERVICE=Deezer
+# Music service to use: Deezer, Qobuz, or SquidWTF (default: SquidWTF)
+MUSIC_SERVICE=SquidWTF
 
 # ===== DEEZER CONFIGURATION =====
 # Deezer ARL token (required if using Deezer)
@@ -32,6 +32,19 @@ QOBUZ_USER_ID=
 # Preferred audio quality: FLAC, FLAC_24_HIGH, FLAC_24_LOW, FLAC_16, MP3_320 (optional)
 # If not specified, the highest available quality will be used
 QOBUZ_QUALITY=
+
+# ===== SQUIDWTF CONFIGURATION =====
+# SquidWTF is a music downloader service that supports Qobuz and Tidal backends
+# No credentials required - this service provides free access to music
+
+# Backend source: Qobuz or Tidal (default: Qobuz)
+SQUIDWTF_SOURCE=Qobuz
+
+# Preferred audio quality (optional)
+# For Qobuz backend: 27 (FLAC 24-bit), 7 (FLAC 16-bit), 6 (MP3 320), 5 (MP3 128)
+# For Tidal backend: HI_RES_LOSSLESS, LOSSLESS
+# If not specified, the highest available quality will be used
+SQUIDWTF_QUALITY=
 
 # ===== GENERAL SETTINGS =====
 # External playlists support (optional, default: true)

--- a/octo-fiesta/Models/Settings/SquidWTFSettings.cs
+++ b/octo-fiesta/Models/Settings/SquidWTFSettings.cs
@@ -1,0 +1,22 @@
+namespace octo_fiesta.Models.Settings;
+
+/// <summary>
+/// Configuration for the SquidWTF music provider
+/// SquidWTF is a music downloader service that supports Qobuz and Tidal backends
+/// </summary>
+public class SquidWTFSettings
+{
+    /// <summary>
+    /// The backend source to use: "Qobuz" or "Tidal"
+    /// Defaults to "Qobuz" if not specified
+    /// </summary>
+    public string Source { get; set; } = "Qobuz";
+    
+    /// <summary>
+    /// Preferred audio quality
+    /// For Qobuz: 27 (FLAC), 7 (MP3 320), 5 (MP3 128)
+    /// For Tidal: "HI_RES_LOSSLESS", "LOSSLESS"
+    /// If not specified, highest quality will be used
+    /// </summary>
+    public string? Quality { get; set; }
+}

--- a/octo-fiesta/Models/Settings/SubsonicSettings.cs
+++ b/octo-fiesta/Models/Settings/SubsonicSettings.cs
@@ -70,7 +70,12 @@ public enum MusicService
     /// <summary>
     /// Qobuz music service
     /// </summary>
-    Qobuz
+    Qobuz,
+    
+    /// <summary>
+    /// SquidWTF music service (supports Qobuz and Tidal backends)
+    /// </summary>
+    SquidWTF
 }
 
 public class SubsonicSettings
@@ -93,11 +98,11 @@ public class SubsonicSettings
     public DownloadMode DownloadMode { get; set; } = DownloadMode.Track;
     
     /// <summary>
-    /// Music service to use (default: Deezer)
+    /// Music service to use (default: SquidWTF)
     /// Environment variable: MUSIC_SERVICE
-    /// Values: "Deezer", "Qobuz"
+    /// Values: "Deezer", "Qobuz", "SquidWTF"
     /// </summary>
-    public MusicService MusicService { get; set; } = MusicService.Deezer;
+    public MusicService MusicService { get; set; } = MusicService.SquidWTF;
     
     /// <summary>
     /// Storage mode for downloaded files (default: Permanent)

--- a/octo-fiesta/Models/SquidWTF/QobuzApiResponses.cs
+++ b/octo-fiesta/Models/SquidWTF/QobuzApiResponses.cs
@@ -1,0 +1,190 @@
+using System.Text.Json.Serialization;
+
+namespace octo_fiesta.Models.SquidWTF;
+
+#region Qobuz API Responses
+
+/// <summary>
+/// Response from /api/get-music (search)
+/// </summary>
+public class QobuzSearchResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+    
+    [JsonPropertyName("data")]
+    public QobuzSearchData? Data { get; set; }
+}
+
+public class QobuzSearchData
+{
+    [JsonPropertyName("albums")]
+    public QobuzAlbumList? Albums { get; set; }
+    
+    [JsonPropertyName("tracks")]
+    public QobuzTrackList? Tracks { get; set; }
+    
+    [JsonPropertyName("artists")]
+    public QobuzArtistList? Artists { get; set; }
+}
+
+public class QobuzAlbumList
+{
+    [JsonPropertyName("items")]
+    public List<QobuzAlbum>? Items { get; set; }
+}
+
+public class QobuzTrackList
+{
+    [JsonPropertyName("items")]
+    public List<QobuzTrack>? Items { get; set; }
+}
+
+public class QobuzArtistList
+{
+    [JsonPropertyName("items")]
+    public List<QobuzArtist>? Items { get; set; }
+}
+
+public class QobuzAlbum
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("artist")]
+    public QobuzArtist? Artist { get; set; }
+    
+    [JsonPropertyName("image")]
+    public QobuzImage? Image { get; set; }
+    
+    [JsonPropertyName("tracks_count")]
+    public int TracksCount { get; set; }
+    
+    [JsonPropertyName("released_at")]
+    public long? ReleasedAt { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("tracks")]
+    public QobuzTrackList? Tracks { get; set; }
+    
+    [JsonPropertyName("genre")]
+    public QobuzGenre? Genre { get; set; }
+}
+
+public class QobuzTrack
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("track_number")]
+    public int TrackNumber { get; set; }
+    
+    [JsonPropertyName("album")]
+    public QobuzAlbum? Album { get; set; }
+    
+    [JsonPropertyName("performer")]
+    public QobuzArtist? Performer { get; set; }
+    
+    [JsonPropertyName("parental_warning")]
+    public bool ParentalWarning { get; set; }
+}
+
+public class QobuzArtist
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+    
+    [JsonPropertyName("image")]
+    public QobuzImage? Image { get; set; }
+    
+    [JsonPropertyName("albums_count")]
+    public int AlbumsCount { get; set; }
+}
+
+public class QobuzImage
+{
+    [JsonPropertyName("small")]
+    public string? Small { get; set; }
+    
+    [JsonPropertyName("thumbnail")]
+    public string? Thumbnail { get; set; }
+    
+    [JsonPropertyName("large")]
+    public string? Large { get; set; }
+}
+
+public class QobuzGenre
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+    
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}
+
+/// <summary>
+/// Response from /api/get-album
+/// </summary>
+public class QobuzAlbumResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+    
+    [JsonPropertyName("data")]
+    public QobuzAlbum? Data { get; set; }
+}
+
+/// <summary>
+/// Response from /api/get-artist
+/// </summary>
+public class QobuzArtistResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+    
+    [JsonPropertyName("data")]
+    public QobuzArtistData? Data { get; set; }
+}
+
+public class QobuzArtistData
+{
+    [JsonPropertyName("artist")]
+    public QobuzArtist? Artist { get; set; }
+    
+    [JsonPropertyName("albums")]
+    public QobuzAlbumList? Albums { get; set; }
+}
+
+/// <summary>
+/// Response from /api/download-music
+/// </summary>
+public class QobuzDownloadResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+    
+    [JsonPropertyName("data")]
+    public QobuzDownloadData? Data { get; set; }
+}
+
+public class QobuzDownloadData
+{
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+}
+
+#endregion

--- a/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
+++ b/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
@@ -1,0 +1,205 @@
+using System.Text.Json.Serialization;
+
+namespace octo_fiesta.Models.SquidWTF;
+
+#region Tidal API Responses (triton.squid.wtf)
+
+/// <summary>
+/// Response from /search/ endpoint
+/// </summary>
+public class TidalSearchResponse
+{
+    [JsonPropertyName("tracks")]
+    public List<TidalTrack>? Tracks { get; set; }
+    
+    [JsonPropertyName("albums")]
+    public List<TidalAlbum>? Albums { get; set; }
+    
+    [JsonPropertyName("artists")]
+    public List<TidalArtist>? Artists { get; set; }
+    
+    [JsonPropertyName("playlists")]
+    public List<TidalPlaylist>? Playlists { get; set; }
+}
+
+public class TidalTrack
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("trackNumber")]
+    public int TrackNumber { get; set; }
+    
+    [JsonPropertyName("volumeNumber")]
+    public int VolumeNumber { get; set; }
+    
+    [JsonPropertyName("explicit")]
+    public bool Explicit { get; set; }
+    
+    [JsonPropertyName("artist")]
+    public TidalArtist? Artist { get; set; }
+    
+    [JsonPropertyName("artists")]
+    public List<TidalArtist>? Artists { get; set; }
+    
+    [JsonPropertyName("album")]
+    public TidalAlbum? Album { get; set; }
+}
+
+public class TidalAlbum
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("cover")]
+    public string? Cover { get; set; }
+    
+    [JsonPropertyName("numberOfTracks")]
+    public int NumberOfTracks { get; set; }
+    
+    [JsonPropertyName("numberOfVolumes")]
+    public int NumberOfVolumes { get; set; }
+    
+    [JsonPropertyName("releaseDate")]
+    public string? ReleaseDate { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("explicit")]
+    public bool Explicit { get; set; }
+    
+    [JsonPropertyName("artist")]
+    public TidalArtist? Artist { get; set; }
+    
+    [JsonPropertyName("artists")]
+    public List<TidalArtist>? Artists { get; set; }
+    
+    [JsonPropertyName("tracks")]
+    public List<TidalTrack>? Tracks { get; set; }
+}
+
+public class TidalArtist
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+    
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+}
+
+public class TidalPlaylist
+{
+    [JsonPropertyName("uuid")]
+    public string? Uuid { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("numberOfTracks")]
+    public int NumberOfTracks { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("image")]
+    public string? Image { get; set; }
+    
+    [JsonPropertyName("creator")]
+    public TidalCreator? Creator { get; set; }
+}
+
+public class TidalCreator
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}
+
+/// <summary>
+/// Response from /track/ endpoint (download)
+/// </summary>
+public class TidalTrackResponse
+{
+    [JsonPropertyName("trackId")]
+    public long TrackId { get; set; }
+    
+    [JsonPropertyName("assetPresentation")]
+    public string? AssetPresentation { get; set; }
+    
+    [JsonPropertyName("audioQuality")]
+    public string? AudioQuality { get; set; }
+    
+    [JsonPropertyName("manifest")]
+    public string? Manifest { get; set; }
+    
+    [JsonPropertyName("manifestMimeType")]
+    public string? ManifestMimeType { get; set; }
+}
+
+/// <summary>
+/// Decoded manifest content (base64 decoded from TidalTrackResponse.Manifest)
+/// </summary>
+public class TidalManifest
+{
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; set; }
+    
+    [JsonPropertyName("codecs")]
+    public string? Codecs { get; set; }
+    
+    [JsonPropertyName("urls")]
+    public List<string>? Urls { get; set; }
+}
+
+/// <summary>
+/// Response from /info/ endpoint (track metadata)
+/// </summary>
+public class TidalTrackInfoResponse
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+    
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public int Duration { get; set; }
+    
+    [JsonPropertyName("trackNumber")]
+    public int TrackNumber { get; set; }
+    
+    [JsonPropertyName("volumeNumber")]
+    public int VolumeNumber { get; set; }
+    
+    [JsonPropertyName("explicit")]
+    public bool Explicit { get; set; }
+    
+    [JsonPropertyName("isrc")]
+    public string? Isrc { get; set; }
+    
+    [JsonPropertyName("artist")]
+    public TidalArtist? Artist { get; set; }
+    
+    [JsonPropertyName("artists")]
+    public List<TidalArtist>? Artists { get; set; }
+    
+    [JsonPropertyName("album")]
+    public TidalAlbum? Album { get; set; }
+}
+
+#endregion

--- a/octo-fiesta/Program.cs
+++ b/octo-fiesta/Program.cs
@@ -2,6 +2,7 @@ using octo_fiesta.Models.Settings;
 using octo_fiesta.Services;
 using octo_fiesta.Services.Deezer;
 using octo_fiesta.Services.Qobuz;
+using octo_fiesta.Services.SquidWTF;
 using octo_fiesta.Services.Local;
 using octo_fiesta.Services.Validation;
 using octo_fiesta.Services.Subsonic;
@@ -29,6 +30,8 @@ builder.Services.Configure<DeezerSettings>(
     builder.Configuration.GetSection("Deezer"));
 builder.Services.Configure<QobuzSettings>(
     builder.Configuration.GetSection("Qobuz"));
+builder.Services.Configure<SquidWTFSettings>(
+    builder.Configuration.GetSection("SquidWTF"));
 
 // Get the configured music service
 var musicService = builder.Configuration.GetValue<MusicService>("Subsonic:MusicService");
@@ -62,6 +65,20 @@ if (musicService == MusicService.Qobuz)
     builder.Services.AddSingleton<IMusicMetadataService, QobuzMetadataService>();
     builder.Services.AddSingleton<IDownloadService, QobuzDownloadService>();
 }
+else if (musicService == MusicService.SquidWTF)
+{
+    // If playlists enabled, register Deezer FIRST (secondary provider)
+    if (enableExternalPlaylists)
+    {
+        builder.Services.AddSingleton<IMusicMetadataService, DeezerMetadataService>();
+        builder.Services.AddSingleton<IDownloadService, DeezerDownloadService>();
+        builder.Services.AddSingleton<PlaylistSyncService>();
+    }
+    
+    // SquidWTF services (primary) - registered LAST to be injected by default
+    builder.Services.AddSingleton<IMusicMetadataService, SquidWTFMetadataService>();
+    builder.Services.AddSingleton<IDownloadService, SquidWTFDownloadService>();
+}
 else
 {
     // If playlists enabled, register Qobuz FIRST (secondary provider)
@@ -82,6 +99,7 @@ else
 builder.Services.AddSingleton<IStartupValidator, SubsonicStartupValidator>();
 builder.Services.AddSingleton<IStartupValidator, DeezerStartupValidator>();
 builder.Services.AddSingleton<IStartupValidator, QobuzStartupValidator>();
+builder.Services.AddSingleton<IStartupValidator, SquidWTFStartupValidator>();
 
 // Register orchestrator as hosted service
 builder.Services.AddHostedService<StartupValidationOrchestrator>();

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -1,0 +1,300 @@
+using System.Text;
+using System.Text.Json;
+using octo_fiesta.Models.Domain;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Models.SquidWTF;
+using octo_fiesta.Services.Local;
+using octo_fiesta.Services.Common;
+using Microsoft.Extensions.Options;
+using IOFile = System.IO.File;
+
+namespace octo_fiesta.Services.SquidWTF;
+
+/// <summary>
+/// Download service implementation using SquidWTF API
+/// Supports both Qobuz and Tidal backends
+/// No decryption needed - SquidWTF returns direct streaming URLs
+/// </summary>
+public class SquidWTFDownloadService : BaseDownloadService
+{
+    private readonly HttpClient _httpClient;
+    private readonly SquidWTFSettings _squidWTFSettings;
+    
+    // API endpoints
+    private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
+    private const string TidalBaseUrl = "https://triton.squid.wtf";
+    
+    // Required headers
+    private const string QobuzCountryHeader = "Token-Country";
+    private const string QobuzCountryValue = "US";
+    private const string TidalClientHeader = "x-client";
+    private const string TidalClientValue = "BiniLossless/v3.4";
+    
+    // Quality mappings
+    // Qobuz: 27 = FLAC (24-bit), 7 = FLAC (16-bit), 6 = MP3 320, 5 = MP3 128
+    // Tidal: HI_RES_LOSSLESS, LOSSLESS
+    
+    private bool IsQobuzSource => _squidWTFSettings.Source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase);
+
+    protected override string ProviderName => "squidwtf";
+
+    public SquidWTFDownloadService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILocalLibraryService localLibraryService,
+        IMusicMetadataService metadataService,
+        IOptions<SubsonicSettings> subsonicSettings,
+        IOptions<SquidWTFSettings> squidWTFSettings,
+        IServiceProvider serviceProvider,
+        ILogger<SquidWTFDownloadService> logger)
+        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, serviceProvider, logger)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _squidWTFSettings = squidWTFSettings.Value;
+    }
+
+    #region BaseDownloadService Implementation
+
+    public override async Task<bool> IsAvailableAsync()
+    {
+        try
+        {
+            // Test connectivity to the appropriate backend
+            if (IsQobuzSource)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, $"{QobuzBaseUrl}/api/get-music?q=test&offset=0");
+                request.Headers.Add(QobuzCountryHeader, QobuzCountryValue);
+                
+                var response = await _httpClient.SendAsync(request);
+                return response.IsSuccessStatusCode;
+            }
+            else
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, $"{TidalBaseUrl}/search/?s=test");
+                request.Headers.Add(TidalClientHeader, TidalClientValue);
+                
+                var response = await _httpClient.SendAsync(request);
+                return response.IsSuccessStatusCode;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "SquidWTF service not available");
+            return false;
+        }
+    }
+
+    protected override string? ExtractExternalIdFromAlbumId(string albumId)
+    {
+        const string prefix = "ext-squidwtf-album-";
+        if (albumId.StartsWith(prefix))
+        {
+            return albumId[prefix.Length..];
+        }
+        return null;
+    }
+
+    protected override string? GetTargetQuality()
+    {
+        if (!string.IsNullOrEmpty(_squidWTFSettings.Quality))
+        {
+            return _squidWTFSettings.Quality;
+        }
+        
+        // Default to highest quality
+        return IsQobuzSource ? "27" : "HI_RES_LOSSLESS";
+    }
+
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    {
+        if (IsQobuzSource)
+        {
+            return await DownloadTrackQobuzAsync(trackId, song, cancellationToken);
+        }
+        else
+        {
+            return await DownloadTrackTidalAsync(trackId, song, cancellationToken);
+        }
+    }
+
+    #endregion
+
+    #region Qobuz Download
+
+    private async Task<DownloadResult> DownloadTrackQobuzAsync(string trackId, Song song, CancellationToken cancellationToken)
+    {
+        // Get download URL
+        var quality = GetQobuzQuality();
+        var url = $"{QobuzBaseUrl}/api/download-music?track_id={trackId}&quality={quality}";
+        
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add(QobuzCountryHeader, QobuzCountryValue);
+        
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var downloadResponse = JsonSerializer.Deserialize<QobuzDownloadResponse>(json);
+        
+        if (downloadResponse?.Success != true || string.IsNullOrEmpty(downloadResponse.Data?.Url))
+        {
+            throw new Exception("Failed to get download URL from SquidWTF Qobuz");
+        }
+        
+        var downloadUrl = downloadResponse.Data.Url;
+        Logger.LogInformation("Got download URL for track {TrackId}: {Title}", trackId, song.Title);
+        
+        // Determine file extension based on quality
+        var extension = quality == "27" || quality == "7" ? ".flac" : ".mp3";
+        var downloadedQuality = quality switch
+        {
+            "27" => "FLAC_24",
+            "7" => "FLAC_16",
+            "6" => "MP3_320",
+            "5" => "MP3_128",
+            _ => "FLAC"
+        };
+        
+        // Build output path
+        var artistForPath = song.AlbumArtist ?? song.Artist;
+        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        
+        // Create directories
+        var albumFolder = Path.GetDirectoryName(outputPath)!;
+        EnsureDirectoryExists(albumFolder);
+        
+        // Resolve unique path if file already exists
+        outputPath = PathHelper.ResolveUniquePath(outputPath);
+        
+        // Download the file (no decryption needed)
+        await DownloadFileAsync(downloadUrl, outputPath, cancellationToken);
+        
+        // Write metadata
+        await WriteMetadataAsync(outputPath, song, cancellationToken);
+        
+        return new DownloadResult(outputPath, downloadedQuality);
+    }
+
+    private string GetQobuzQuality()
+    {
+        var quality = _squidWTFSettings.Quality;
+        
+        if (string.IsNullOrEmpty(quality))
+        {
+            return "27"; // Default to highest quality FLAC
+        }
+        
+        // Map common quality names to Qobuz quality codes
+        return quality.ToUpperInvariant() switch
+        {
+            "FLAC" or "FLAC_24" or "27" => "27",
+            "FLAC_16" or "7" => "7",
+            "MP3_320" or "6" => "6",
+            "MP3_128" or "5" => "5",
+            _ => "27"
+        };
+    }
+
+    #endregion
+
+    #region Tidal Download
+
+    private async Task<DownloadResult> DownloadTrackTidalAsync(string trackId, Song song, CancellationToken cancellationToken)
+    {
+        // Get download manifest
+        var quality = GetTidalQuality();
+        var url = $"{TidalBaseUrl}/track/?id={trackId}&quality={quality}";
+        
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add(TidalClientHeader, TidalClientValue);
+        
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var trackResponse = JsonSerializer.Deserialize<TidalTrackResponse>(json);
+        
+        if (string.IsNullOrEmpty(trackResponse?.Manifest))
+        {
+            throw new Exception("Failed to get manifest from SquidWTF Tidal");
+        }
+        
+        // Decode the base64 manifest
+        var manifestJson = Encoding.UTF8.GetString(Convert.FromBase64String(trackResponse.Manifest));
+        var manifest = JsonSerializer.Deserialize<TidalManifest>(manifestJson);
+        
+        if (manifest?.Urls == null || manifest.Urls.Count == 0)
+        {
+            throw new Exception("No download URLs in Tidal manifest");
+        }
+        
+        var downloadUrl = manifest.Urls[0];
+        Logger.LogInformation("Got download URL for track {TrackId}: {Title}", trackId, song.Title);
+        
+        // Determine file extension based on manifest mime type or quality
+        var extension = manifest.MimeType?.Contains("flac") == true ? ".flac" : ".mp3";
+        var downloadedQuality = quality == "HI_RES_LOSSLESS" ? "FLAC_24" : "FLAC_16";
+        
+        // Build output path
+        var artistForPath = song.AlbumArtist ?? song.Artist;
+        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        
+        // Create directories
+        var albumFolder = Path.GetDirectoryName(outputPath)!;
+        EnsureDirectoryExists(albumFolder);
+        
+        // Resolve unique path if file already exists
+        outputPath = PathHelper.ResolveUniquePath(outputPath);
+        
+        // Download the file (no decryption needed)
+        await DownloadFileAsync(downloadUrl, outputPath, cancellationToken);
+        
+        // Write metadata
+        await WriteMetadataAsync(outputPath, song, cancellationToken);
+        
+        return new DownloadResult(outputPath, downloadedQuality);
+    }
+
+    private string GetTidalQuality()
+    {
+        var quality = _squidWTFSettings.Quality;
+        
+        if (string.IsNullOrEmpty(quality))
+        {
+            return "HI_RES_LOSSLESS"; // Default to highest quality
+        }
+        
+        // Map common quality names to Tidal quality codes
+        return quality.ToUpperInvariant() switch
+        {
+            "HI_RES_LOSSLESS" or "HI_RES" or "FLAC_24" => "HI_RES_LOSSLESS",
+            "LOSSLESS" or "FLAC" or "FLAC_16" => "LOSSLESS",
+            _ => "HI_RES_LOSSLESS"
+        };
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private async Task DownloadFileAsync(string url, string outputPath, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("User-Agent", "Mozilla/5.0");
+        request.Headers.Add("Accept", "*/*");
+        
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var outputFile = IOFile.Create(outputPath);
+        
+        await responseStream.CopyToAsync(outputFile, cancellationToken);
+        
+        Logger.LogInformation("Downloaded file to: {Path}", outputPath);
+    }
+
+    #endregion
+}

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -1,0 +1,790 @@
+using octo_fiesta.Models.Domain;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Models.Search;
+using octo_fiesta.Models.Subsonic;
+using octo_fiesta.Models.SquidWTF;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace octo_fiesta.Services.SquidWTF;
+
+/// <summary>
+/// Metadata service implementation using SquidWTF API
+/// Supports both Qobuz and Tidal backends
+/// </summary>
+public class SquidWTFMetadataService : IMusicMetadataService
+{
+    private readonly HttpClient _httpClient;
+    private readonly SquidWTFSettings _settings;
+    private readonly SubsonicSettings _subsonicSettings;
+    private readonly ILogger<SquidWTFMetadataService> _logger;
+    
+    // API endpoints
+    private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
+    private const string TidalBaseUrl = "https://triton.squid.wtf";
+    
+    // Required headers
+    private const string QobuzCountryHeader = "Token-Country";
+    private const string QobuzCountryValue = "US";
+    private const string TidalClientHeader = "x-client";
+    private const string TidalClientValue = "BiniLossless/v3.4";
+    
+    private bool IsQobuzSource => _settings.Source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase);
+
+    public SquidWTFMetadataService(
+        IHttpClientFactory httpClientFactory, 
+        IOptions<SquidWTFSettings> settings,
+        IOptions<SubsonicSettings> subsonicSettings,
+        ILogger<SquidWTFMetadataService> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _settings = settings.Value;
+        _subsonicSettings = subsonicSettings.Value;
+        _logger = logger;
+    }
+
+    #region IMusicMetadataService Implementation
+
+    public async Task<List<Song>> SearchSongsAsync(string query, int limit = 20)
+    {
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await SearchSongsQobuzAsync(query, limit);
+            }
+            else
+            {
+                return await SearchSongsTidalAsync(query, limit);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to search songs for query: {Query}", query);
+            return new List<Song>();
+        }
+    }
+
+    public async Task<List<Album>> SearchAlbumsAsync(string query, int limit = 20)
+    {
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await SearchAlbumsQobuzAsync(query, limit);
+            }
+            else
+            {
+                return await SearchAlbumsTidalAsync(query, limit);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to search albums for query: {Query}", query);
+            return new List<Album>();
+        }
+    }
+
+    public async Task<List<Artist>> SearchArtistsAsync(string query, int limit = 20)
+    {
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await SearchArtistsQobuzAsync(query, limit);
+            }
+            else
+            {
+                return await SearchArtistsTidalAsync(query, limit);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to search artists for query: {Query}", query);
+            return new List<Artist>();
+        }
+    }
+
+    public async Task<SearchResult> SearchAllAsync(string query, int songLimit = 20, int albumLimit = 20, int artistLimit = 20)
+    {
+        var songsTask = SearchSongsAsync(query, songLimit);
+        var albumsTask = SearchAlbumsAsync(query, albumLimit);
+        var artistsTask = SearchArtistsAsync(query, artistLimit);
+        
+        await Task.WhenAll(songsTask, albumsTask, artistsTask);
+        
+        return new SearchResult
+        {
+            Songs = await songsTask,
+            Albums = await albumsTask,
+            Artists = await artistsTask
+        };
+    }
+
+    public async Task<Song?> GetSongAsync(string externalProvider, string externalId)
+    {
+        if (externalProvider != "squidwtf") return null;
+        
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await GetSongQobuzAsync(externalId);
+            }
+            else
+            {
+                return await GetSongTidalAsync(externalId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get song: {ExternalId}", externalId);
+            return null;
+        }
+    }
+
+    public async Task<Album?> GetAlbumAsync(string externalProvider, string externalId)
+    {
+        if (externalProvider != "squidwtf") return null;
+        
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await GetAlbumQobuzAsync(externalId);
+            }
+            else
+            {
+                return await GetAlbumTidalAsync(externalId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get album: {ExternalId}", externalId);
+            return null;
+        }
+    }
+
+    public async Task<Artist?> GetArtistAsync(string externalProvider, string externalId)
+    {
+        if (externalProvider != "squidwtf") return null;
+        
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await GetArtistQobuzAsync(externalId);
+            }
+            else
+            {
+                return await GetArtistTidalAsync(externalId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get artist: {ExternalId}", externalId);
+            return null;
+        }
+    }
+
+    public async Task<List<Album>> GetArtistAlbumsAsync(string externalProvider, string externalId)
+    {
+        if (externalProvider != "squidwtf") return new List<Album>();
+        
+        try
+        {
+            if (IsQobuzSource)
+            {
+                return await GetArtistAlbumsQobuzAsync(externalId);
+            }
+            else
+            {
+                return await GetArtistAlbumsTidalAsync(externalId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get artist albums: {ExternalId}", externalId);
+            return new List<Album>();
+        }
+    }
+
+    public async Task<List<ExternalPlaylist>> SearchPlaylistsAsync(string query, int limit = 20)
+    {
+        try
+        {
+            // Only Tidal supports playlist search
+            if (!IsQobuzSource)
+            {
+                return await SearchPlaylistsTidalAsync(query, limit);
+            }
+            
+            return new List<ExternalPlaylist>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to search playlists for query: {Query}", query);
+            return new List<ExternalPlaylist>();
+        }
+    }
+
+    public Task<ExternalPlaylist?> GetPlaylistAsync(string externalProvider, string externalId)
+    {
+        // Not implemented for SquidWTF
+        return Task.FromResult<ExternalPlaylist?>(null);
+    }
+
+    public Task<List<Song>> GetPlaylistTracksAsync(string externalProvider, string externalId)
+    {
+        // Not implemented for SquidWTF
+        return Task.FromResult(new List<Song>());
+    }
+
+    #endregion
+
+    #region Qobuz Backend Methods
+
+    private async Task<List<Song>> SearchSongsQobuzAsync(string query, int limit)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-music?q={Uri.EscapeDataString(query)}&offset=0";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return new List<Song>();
+        
+        var searchResponse = JsonSerializer.Deserialize<QobuzSearchResponse>(response);
+        if (searchResponse?.Data?.Tracks?.Items == null) return new List<Song>();
+        
+        var songs = new List<Song>();
+        foreach (var track in searchResponse.Data.Tracks.Items.Take(limit))
+        {
+            var song = MapQobuzTrackToSong(track);
+            if (ShouldIncludeSong(song))
+            {
+                songs.Add(song);
+            }
+        }
+        
+        return songs;
+    }
+
+    private async Task<List<Album>> SearchAlbumsQobuzAsync(string query, int limit)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-music?q={Uri.EscapeDataString(query)}&offset=0";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return new List<Album>();
+        
+        var searchResponse = JsonSerializer.Deserialize<QobuzSearchResponse>(response);
+        if (searchResponse?.Data?.Albums?.Items == null) return new List<Album>();
+        
+        return searchResponse.Data.Albums.Items
+            .Take(limit)
+            .Select(MapQobuzAlbumToAlbum)
+            .ToList();
+    }
+
+    private async Task<List<Artist>> SearchArtistsQobuzAsync(string query, int limit)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-music?q={Uri.EscapeDataString(query)}&offset=0";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return new List<Artist>();
+        
+        var searchResponse = JsonSerializer.Deserialize<QobuzSearchResponse>(response);
+        if (searchResponse?.Data?.Artists?.Items == null) return new List<Artist>();
+        
+        return searchResponse.Data.Artists.Items
+            .Take(limit)
+            .Select(MapQobuzArtistToArtist)
+            .ToList();
+    }
+
+    private async Task<Song?> GetSongQobuzAsync(string trackId)
+    {
+        // Qobuz doesn't have a direct track endpoint, get from album
+        // For now, return a basic song object - full metadata will come from album
+        var url = $"{QobuzBaseUrl}/api/get-music?q={trackId}&offset=0";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var searchResponse = JsonSerializer.Deserialize<QobuzSearchResponse>(response);
+        var track = searchResponse?.Data?.Tracks?.Items?.FirstOrDefault(t => t.Id.ToString() == trackId);
+        
+        if (track == null) return null;
+        
+        return MapQobuzTrackToSong(track);
+    }
+
+    private async Task<Album?> GetAlbumQobuzAsync(string albumId)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-album?album_id={albumId}";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var albumResponse = JsonSerializer.Deserialize<QobuzAlbumResponse>(response);
+        if (albumResponse?.Data == null) return null;
+        
+        var album = MapQobuzAlbumToAlbum(albumResponse.Data);
+        
+        // Add tracks
+        if (albumResponse.Data.Tracks?.Items != null)
+        {
+            foreach (var track in albumResponse.Data.Tracks.Items)
+            {
+                var song = MapQobuzTrackToSong(track);
+                song.Album = album.Title;
+                song.AlbumId = album.Id;
+                song.AlbumArtist = album.Artist;
+                
+                if (ShouldIncludeSong(song))
+                {
+                    album.Songs.Add(song);
+                }
+            }
+        }
+        
+        return album;
+    }
+
+    private async Task<Artist?> GetArtistQobuzAsync(string artistId)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-artist?artist_id={artistId}";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var artistResponse = JsonSerializer.Deserialize<QobuzArtistResponse>(response);
+        if (artistResponse?.Data?.Artist == null) return null;
+        
+        return MapQobuzArtistToArtist(artistResponse.Data.Artist);
+    }
+
+    private async Task<List<Album>> GetArtistAlbumsQobuzAsync(string artistId)
+    {
+        var url = $"{QobuzBaseUrl}/api/get-artist?artist_id={artistId}";
+        var response = await SendQobuzRequestAsync(url);
+        
+        if (response == null) return new List<Album>();
+        
+        var artistResponse = JsonSerializer.Deserialize<QobuzArtistResponse>(response);
+        if (artistResponse?.Data?.Albums?.Items == null) return new List<Album>();
+        
+        return artistResponse.Data.Albums.Items
+            .Select(MapQobuzAlbumToAlbum)
+            .ToList();
+    }
+
+    private async Task<string?> SendQobuzRequestAsync(string url)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add(QobuzCountryHeader, QobuzCountryValue);
+            
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Qobuz API returned {StatusCode} for {Url}", response.StatusCode, url);
+                return null;
+            }
+            
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send Qobuz request to {Url}", url);
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region Tidal Backend Methods
+
+    private async Task<List<Song>> SearchSongsTidalAsync(string query, int limit)
+    {
+        var url = $"{TidalBaseUrl}/search/?s={Uri.EscapeDataString(query)}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return new List<Song>();
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        if (searchResponse?.Tracks == null) return new List<Song>();
+        
+        var songs = new List<Song>();
+        foreach (var track in searchResponse.Tracks.Take(limit))
+        {
+            var song = MapTidalTrackToSong(track);
+            if (ShouldIncludeSong(song))
+            {
+                songs.Add(song);
+            }
+        }
+        
+        return songs;
+    }
+
+    private async Task<List<Album>> SearchAlbumsTidalAsync(string query, int limit)
+    {
+        var url = $"{TidalBaseUrl}/search/?al={Uri.EscapeDataString(query)}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return new List<Album>();
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        if (searchResponse?.Albums == null) return new List<Album>();
+        
+        return searchResponse.Albums
+            .Take(limit)
+            .Select(MapTidalAlbumToAlbum)
+            .ToList();
+    }
+
+    private async Task<List<Artist>> SearchArtistsTidalAsync(string query, int limit)
+    {
+        var url = $"{TidalBaseUrl}/search/?a={Uri.EscapeDataString(query)}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return new List<Artist>();
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        if (searchResponse?.Artists == null) return new List<Artist>();
+        
+        return searchResponse.Artists
+            .Take(limit)
+            .Select(MapTidalArtistToArtist)
+            .ToList();
+    }
+
+    private async Task<List<ExternalPlaylist>> SearchPlaylistsTidalAsync(string query, int limit)
+    {
+        var url = $"{TidalBaseUrl}/search/?p={Uri.EscapeDataString(query)}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return new List<ExternalPlaylist>();
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        if (searchResponse?.Playlists == null) return new List<ExternalPlaylist>();
+        
+        return searchResponse.Playlists
+            .Take(limit)
+            .Select(MapTidalPlaylistToExternalPlaylist)
+            .ToList();
+    }
+
+    private async Task<Song?> GetSongTidalAsync(string trackId)
+    {
+        var url = $"{TidalBaseUrl}/info/?id={trackId}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var trackInfo = JsonSerializer.Deserialize<TidalTrackInfoResponse>(response);
+        if (trackInfo == null) return null;
+        
+        return MapTidalTrackInfoToSong(trackInfo);
+    }
+
+    private async Task<Album?> GetAlbumTidalAsync(string albumId)
+    {
+        // Tidal search by album ID - search for the album and get details
+        var url = $"{TidalBaseUrl}/search/?al={albumId}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        var albumData = searchResponse?.Albums?.FirstOrDefault(a => a.Id.ToString() == albumId);
+        
+        if (albumData == null) return null;
+        
+        var album = MapTidalAlbumToAlbum(albumData);
+        
+        // Add tracks if available
+        if (albumData.Tracks != null)
+        {
+            foreach (var track in albumData.Tracks)
+            {
+                var song = MapTidalTrackToSong(track);
+                song.Album = album.Title;
+                song.AlbumId = album.Id;
+                song.AlbumArtist = album.Artist;
+                
+                if (ShouldIncludeSong(song))
+                {
+                    album.Songs.Add(song);
+                }
+            }
+        }
+        
+        return album;
+    }
+
+    private async Task<Artist?> GetArtistTidalAsync(string artistId)
+    {
+        var url = $"{TidalBaseUrl}/search/?a={artistId}";
+        var response = await SendTidalRequestAsync(url);
+        
+        if (response == null) return null;
+        
+        var searchResponse = JsonSerializer.Deserialize<TidalSearchResponse>(response);
+        var artistData = searchResponse?.Artists?.FirstOrDefault(a => a.Id.ToString() == artistId);
+        
+        if (artistData == null) return null;
+        
+        return MapTidalArtistToArtist(artistData);
+    }
+
+    private Task<List<Album>> GetArtistAlbumsTidalAsync(string artistId)
+    {
+        // Tidal doesn't have a direct artist albums endpoint via SquidWTF
+        // Return empty list for now
+        return Task.FromResult(new List<Album>());
+    }
+
+    private async Task<string?> SendTidalRequestAsync(string url)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add(TidalClientHeader, TidalClientValue);
+            
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Tidal API returned {StatusCode} for {Url}", response.StatusCode, url);
+                return null;
+            }
+            
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send Tidal request to {Url}", url);
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region Mapping Methods - Qobuz
+
+    private Song MapQobuzTrackToSong(QobuzTrack track)
+    {
+        var externalId = track.Id.ToString();
+        
+        return new Song
+        {
+            Id = $"ext-squidwtf-song-{externalId}",
+            Title = track.Title ?? "",
+            Artist = track.Performer?.Name ?? "",
+            ArtistId = track.Performer != null ? $"ext-squidwtf-artist-{track.Performer.Id}" : null,
+            Album = track.Album?.Title ?? "",
+            AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
+            Duration = track.Duration,
+            Track = track.TrackNumber,
+            CoverArtUrl = track.Album?.Image?.Thumbnail ?? track.Album?.Image?.Small,
+            CoverArtUrlLarge = track.Album?.Image?.Large,
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId,
+            ExplicitContentLyrics = track.ParentalWarning ? 1 : 0
+        };
+    }
+
+    private Album MapQobuzAlbumToAlbum(QobuzAlbum album)
+    {
+        var externalId = album.Id ?? "";
+        
+        int? year = null;
+        if (album.ReleasedAt.HasValue)
+        {
+            var dateTime = DateTimeOffset.FromUnixTimeSeconds(album.ReleasedAt.Value).DateTime;
+            year = dateTime.Year;
+        }
+        
+        return new Album
+        {
+            Id = $"ext-squidwtf-album-{externalId}",
+            Title = album.Title ?? "",
+            Artist = album.Artist?.Name ?? "",
+            ArtistId = album.Artist != null ? $"ext-squidwtf-artist-{album.Artist.Id}" : null,
+            Year = year,
+            SongCount = album.TracksCount,
+            CoverArtUrl = album.Image?.Thumbnail ?? album.Image?.Small,
+            Genre = album.Genre?.Name,
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId
+        };
+    }
+
+    private Artist MapQobuzArtistToArtist(QobuzArtist artist)
+    {
+        var externalId = artist.Id.ToString();
+        
+        return new Artist
+        {
+            Id = $"ext-squidwtf-artist-{externalId}",
+            Name = artist.Name ?? "",
+            ImageUrl = artist.Image?.Large ?? artist.Image?.Thumbnail,
+            AlbumCount = artist.AlbumsCount > 0 ? artist.AlbumsCount : null,
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId
+        };
+    }
+
+    #endregion
+
+    #region Mapping Methods - Tidal
+
+    private Song MapTidalTrackToSong(TidalTrack track)
+    {
+        var externalId = track.Id.ToString();
+        
+        return new Song
+        {
+            Id = $"ext-squidwtf-song-{externalId}",
+            Title = track.Title ?? "",
+            Artist = track.Artist?.Name ?? (track.Artists?.FirstOrDefault()?.Name ?? ""),
+            ArtistId = track.Artist != null ? $"ext-squidwtf-artist-{track.Artist.Id}" : null,
+            Album = track.Album?.Title ?? "",
+            AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
+            Duration = track.Duration,
+            Track = track.TrackNumber,
+            DiscNumber = track.VolumeNumber,
+            CoverArtUrl = GetTidalCoverUrl(track.Album?.Cover, "320x320"),
+            CoverArtUrlLarge = GetTidalCoverUrl(track.Album?.Cover, "1280x1280"),
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId,
+            ExplicitContentLyrics = track.Explicit ? 1 : 0
+        };
+    }
+
+    private Song MapTidalTrackInfoToSong(TidalTrackInfoResponse track)
+    {
+        var externalId = track.Id.ToString();
+        
+        return new Song
+        {
+            Id = $"ext-squidwtf-song-{externalId}",
+            Title = track.Title ?? "",
+            Artist = track.Artist?.Name ?? (track.Artists?.FirstOrDefault()?.Name ?? ""),
+            ArtistId = track.Artist != null ? $"ext-squidwtf-artist-{track.Artist.Id}" : null,
+            Album = track.Album?.Title ?? "",
+            AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
+            Duration = track.Duration,
+            Track = track.TrackNumber,
+            DiscNumber = track.VolumeNumber,
+            Isrc = track.Isrc,
+            CoverArtUrl = GetTidalCoverUrl(track.Album?.Cover, "320x320"),
+            CoverArtUrlLarge = GetTidalCoverUrl(track.Album?.Cover, "1280x1280"),
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId,
+            ExplicitContentLyrics = track.Explicit ? 1 : 0
+        };
+    }
+
+    private Album MapTidalAlbumToAlbum(TidalAlbum album)
+    {
+        var externalId = album.Id.ToString();
+        
+        int? year = null;
+        if (!string.IsNullOrEmpty(album.ReleaseDate) && album.ReleaseDate.Length >= 4)
+        {
+            if (int.TryParse(album.ReleaseDate.Substring(0, 4), out var y))
+            {
+                year = y;
+            }
+        }
+        
+        return new Album
+        {
+            Id = $"ext-squidwtf-album-{externalId}",
+            Title = album.Title ?? "",
+            Artist = album.Artist?.Name ?? (album.Artists?.FirstOrDefault()?.Name ?? ""),
+            ArtistId = album.Artist != null ? $"ext-squidwtf-artist-{album.Artist.Id}" : null,
+            Year = year,
+            SongCount = album.NumberOfTracks,
+            CoverArtUrl = GetTidalCoverUrl(album.Cover, "320x320"),
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId
+        };
+    }
+
+    private Artist MapTidalArtistToArtist(TidalArtist artist)
+    {
+        var externalId = artist.Id.ToString();
+        
+        return new Artist
+        {
+            Id = $"ext-squidwtf-artist-{externalId}",
+            Name = artist.Name ?? "",
+            ImageUrl = GetTidalImageUrl(artist.Picture),
+            IsLocal = false,
+            ExternalProvider = "squidwtf",
+            ExternalId = externalId
+        };
+    }
+
+    private ExternalPlaylist MapTidalPlaylistToExternalPlaylist(TidalPlaylist playlist)
+    {
+        return new ExternalPlaylist
+        {
+            Id = Common.PlaylistIdHelper.CreatePlaylistId("squidwtf", playlist.Uuid ?? ""),
+            Name = playlist.Title ?? "",
+            CuratorName = playlist.Creator?.Name,
+            Provider = "squidwtf",
+            ExternalId = playlist.Uuid ?? "",
+            TrackCount = playlist.NumberOfTracks,
+            Duration = playlist.Duration,
+            CoverUrl = playlist.Image
+        };
+    }
+
+    private static string? GetTidalCoverUrl(string? coverId, string size = "320x320")
+    {
+        if (string.IsNullOrEmpty(coverId)) return null;
+        
+        // Tidal cover IDs need dashes replaced with slashes
+        var formattedId = coverId.Replace("-", "/");
+        return $"https://resources.tidal.com/images/{formattedId}/{size}.jpg";
+    }
+
+    private static string? GetTidalImageUrl(string? pictureId)
+    {
+        if (string.IsNullOrEmpty(pictureId)) return null;
+        
+        var formattedId = pictureId.Replace("-", "/");
+        return $"https://resources.tidal.com/images/{formattedId}/320x320.jpg";
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Determines whether a song should be included based on the explicit content filter setting
+    /// </summary>
+    private bool ShouldIncludeSong(Song song)
+    {
+        if (song.ExplicitContentLyrics == null)
+            return true;
+        
+        return _subsonicSettings.ExplicitFilter switch
+        {
+            ExplicitFilter.All => true,
+            ExplicitFilter.ExplicitOnly => song.ExplicitContentLyrics != 3,
+            ExplicitFilter.CleanOnly => song.ExplicitContentLyrics != 1,
+            _ => true
+        };
+    }
+
+    #endregion
+}

--- a/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.Options;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Services.Validation;
+
+namespace octo_fiesta.Services.SquidWTF;
+
+/// <summary>
+/// Validates SquidWTF service connectivity at startup
+/// </summary>
+public class SquidWTFStartupValidator : BaseStartupValidator
+{
+    private readonly SquidWTFSettings _settings;
+    
+    // API endpoints
+    private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
+    private const string TidalBaseUrl = "https://triton.squid.wtf";
+    
+    // Required headers
+    private const string QobuzCountryHeader = "Token-Country";
+    private const string QobuzCountryValue = "US";
+    private const string TidalClientHeader = "x-client";
+    private const string TidalClientValue = "BiniLossless/v3.4";
+
+    public override string ServiceName => "SquidWTF";
+
+    public SquidWTFStartupValidator(IOptions<SquidWTFSettings> settings, HttpClient httpClient)
+        : base(httpClient)
+    {
+        _settings = settings.Value;
+    }
+
+    public override async Task<ValidationResult> ValidateAsync(CancellationToken cancellationToken)
+    {
+        var source = _settings.Source ?? "Qobuz";
+        var quality = _settings.Quality;
+        var isQobuz = source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase);
+
+        WriteStatus("SquidWTF Source", source, ConsoleColor.Cyan);
+        
+        var qualityDisplay = string.IsNullOrWhiteSpace(quality) 
+            ? "auto (highest available)" 
+            : quality;
+        WriteStatus("SquidWTF Quality", qualityDisplay, ConsoleColor.Cyan);
+
+        // Test connectivity
+        try
+        {
+            if (isQobuz)
+            {
+                await ValidateQobuzAsync(cancellationToken);
+            }
+            else
+            {
+                await ValidateTidalAsync(cancellationToken);
+            }
+
+            return ValidationResult.Success("SquidWTF validation completed");
+        }
+        catch (TaskCanceledException)
+        {
+            WriteStatus("SquidWTF API", "TIMEOUT", ConsoleColor.Yellow);
+            WriteDetail("Could not reach service within timeout period");
+            return ValidationResult.Failure("TIMEOUT", "Service unreachable", ConsoleColor.Yellow);
+        }
+        catch (HttpRequestException ex)
+        {
+            WriteStatus("SquidWTF API", "UNREACHABLE", ConsoleColor.Yellow);
+            WriteDetail(ex.Message);
+            return ValidationResult.Failure("UNREACHABLE", ex.Message, ConsoleColor.Yellow);
+        }
+        catch (Exception ex)
+        {
+            WriteStatus("SquidWTF API", "ERROR", ConsoleColor.Red);
+            WriteDetail(ex.Message);
+            return ValidationResult.Failure("ERROR", ex.Message, ConsoleColor.Red);
+        }
+    }
+
+    private async Task ValidateQobuzAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, 
+            $"{QobuzBaseUrl}/api/get-music?q=test&offset=0");
+        request.Headers.Add(QobuzCountryHeader, QobuzCountryValue);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            WriteStatus("SquidWTF Qobuz API", "AVAILABLE", ConsoleColor.Green);
+            WriteDetail("Service is responding normally");
+        }
+        else
+        {
+            WriteStatus("SquidWTF Qobuz API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
+            WriteDetail("Service returned an error status");
+        }
+    }
+
+    private async Task ValidateTidalAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, 
+            $"{TidalBaseUrl}/search/?s=test");
+        request.Headers.Add(TidalClientHeader, TidalClientValue);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            WriteStatus("SquidWTF Tidal API", "AVAILABLE", ConsoleColor.Green);
+            WriteDetail("Service is responding normally");
+        }
+        else
+        {
+            WriteStatus("SquidWTF Tidal API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
+            WriteDetail("Service returned an error status");
+        }
+    }
+}

--- a/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
+++ b/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
@@ -41,11 +41,9 @@ public class PlaylistSyncService
         IOptions<SubsonicSettings> subsonicSettings,
         ILogger<PlaylistSyncService> logger)
     {
-        // Get Deezer and Qobuz metadata services
-        _deezerMetadataService = metadataServices.FirstOrDefault(s => s.GetType().Name.Contains("Deezer"))
-            ?? throw new InvalidOperationException("Deezer metadata service not found");
-        _qobuzMetadataService = metadataServices.FirstOrDefault(s => s.GetType().Name.Contains("Qobuz"))
-            ?? throw new InvalidOperationException("Qobuz metadata service not found");
+        // Get Deezer and Qobuz metadata services (optional - may not be registered for SquidWTF)
+        _deezerMetadataService = metadataServices.FirstOrDefault(s => s.GetType().Name.Contains("Deezer"))!;
+        _qobuzMetadataService = metadataServices.FirstOrDefault(s => s.GetType().Name.Contains("Qobuz"))!;
         
         _downloadServices = downloadServices;
         _configuration = configuration;
@@ -72,8 +70,8 @@ public class PlaylistSyncService
     {
         return provider.ToLower() switch
         {
-            "deezer" => _deezerMetadataService,
-            "qobuz" => _qobuzMetadataService,
+            "deezer" when _deezerMetadataService != null => _deezerMetadataService,
+            "qobuz" when _qobuzMetadataService != null => _qobuzMetadataService,
             _ => null
         };
     }


### PR DESCRIPTION
SquidWTF is a third-party service that provides access to Qobuz and Tidal catalogs without requiring personal credentials.

Added metadata service for search (songs, albums, artists, playlists) and download service with direct streaming URLs (no decryption needed)

Supported backends:
- Qobuz (qobuz.squid.wtf) - Default, FLAC 24-bit support
- Tidal (triton.squid.wtf) - HI_RES_LOSSLESS support, playlist search

Configuration
MUSIC_SERVICE=SquidWTF
SQUIDWTF_SOURCE=Qobuz  # or Tidal
SQUIDWTF_QUALITY=27    # Qobuz: 27/7/6/5, Tidal: HI_RES_LOSSLESS/LOSSLESS

#45 

