### PR TITLE
Quick fix: change API endpoints for external metadata and downloading

### DIFF
--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -22,7 +22,7 @@ public class SquidWTFDownloadService : BaseDownloadService
     
     // API endpoints
     private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
-    private const string TidalBaseUrl = "https://triton.squid.wtf";
+    private const string TidalBaseUrl = "https://tidal-api.binimum.org";
     
     // Required headers
     private const string QobuzCountryHeader = "Token-Country";

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -21,7 +21,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
     
     // API endpoints
     private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
-    private const string TidalBaseUrl = "https://triton.squid.wtf";
+    private const string TidalBaseUrl = "https://tidal-api.binimum.org";
     
     // Required headers
     private const string QobuzCountryHeader = "Token-Country";

--- a/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
@@ -40,7 +40,7 @@ public class SquidWTFStartupValidator : BaseStartupValidator
         // Test connectivity to triton.squid.wtf
         try
         {
-            var response = await _httpClient.GetAsync("https://triton.squid.wtf/", cancellationToken);
+            var response = await _httpClient.GetAsync("https://tidal-api.binimum.org/", cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {
@@ -84,7 +84,7 @@ public class SquidWTFStartupValidator : BaseStartupValidator
         try
         {
             // Test search with a simple query
-            var searchUrl = "https://triton.squid.wtf/search/?s=Taylor%20Swift";
+            var searchUrl = "https://tidal-api.binimum.org/search/?s=Taylor%20Swift";
             var searchResponse = await _httpClient.GetAsync(searchUrl, cancellationToken);
 
             if (searchResponse.IsSuccessStatusCode)


### PR DESCRIPTION
Changes: Replace Triton API endpoints with tidal-api.binimum

Reason: Serves as temporary solution to get Octo-Fiesta working again while SquidWTF implementation is reworked.