### PR TITLE
feat: add automatic instance failover for SquidWTF Tidal backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ SQUIDWTF_SOURCE=Qobuz
 # If not specified, the highest available quality will be used
 SQUIDWTF_QUALITY=
 
+# Instance timeout in seconds (optional, default: 5)
+# Only applies to Tidal backend, if an API instance doesn't respond within this time,
+# automatically switches to the next available instance
+SQUIDWTF_INSTANCE_TIMEOUT=5
+
 # ===== GENERAL SETTINGS =====
 # External playlists support (optional, default: true)
 # When enabled, allows searching and downloading playlists from Deezer/Qobuz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,5 +53,8 @@ services:
       # Qobuz: 27 (FLAC 24-bit), 7 (FLAC 16-bit), 6 (MP3 320), 5 (MP3 128)
       # Tidal: HI_RES_LOSSLESS, LOSSLESS
       - SquidWTF__Quality=${SQUIDWTF_QUALITY:-}
+      # Instance timeout in seconds for Tidal backend (default: 5)
+      # Switches to next instance if current one doesn't respond in time
+      - SquidWTF__InstanceTimeoutSeconds=${SQUIDWTF_INSTANCE_TIMEOUT:-5}
     volumes:
       - ${DOWNLOAD_PATH:-./downloads}:/app/downloads

--- a/octo-fiesta/Models/Settings/SquidWTFSettings.cs
+++ b/octo-fiesta/Models/Settings/SquidWTFSettings.cs
@@ -19,4 +19,10 @@ public class SquidWTFSettings
     /// If not specified, highest quality will be used
     /// </summary>
     public string? Quality { get; set; }
+    
+    /// <summary>
+    /// Timeout in seconds for API instance requests before switching to next instance
+    /// Only applies to Tidal source. Defaults to 5 seconds if not specified.
+    /// </summary>
+    public int InstanceTimeoutSeconds { get; set; } = 5;
 }

--- a/octo-fiesta/Program.cs
+++ b/octo-fiesta/Program.cs
@@ -78,6 +78,9 @@ else if (musicService == MusicService.SquidWTF)
         builder.Services.AddSingleton<PlaylistSyncService>();
     }
     
+    // Instance manager for automatic API failover (required for Tidal)
+    builder.Services.AddSingleton<SquidWTFInstanceManager>();
+    
     // SquidWTF services (primary) - registered LAST to be injected by default
     builder.Services.AddSingleton<IMusicMetadataService, SquidWTFMetadataService>();
     builder.Services.AddSingleton<IDownloadService, SquidWTFDownloadService>();

--- a/octo-fiesta/Services/SquidWTF/SquidWTFInstanceManager.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFInstanceManager.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using octo_fiesta.Models.Settings;
+using Microsoft.Extensions.Options;
+
+namespace octo_fiesta.Services.SquidWTF;
+
+/// <summary>
+/// Manages SquidWTF API instances with automatic failover
+/// Fetches available instances from remote JSON and switches to the next one if timeout occurs
+/// </summary>
+public class SquidWTFInstanceManager
+{
+    private readonly HttpClient _httpClient;
+    private readonly SquidWTFSettings _settings;
+    private readonly ILogger<SquidWTFInstanceManager> _logger;
+    
+    private const string InstancesJsonUrl = "https://raw.githubusercontent.com/SamidyFR/monochrome/main/public/instances.json";
+    private const int DefaultTimeoutSeconds = 5;
+    
+    // Static Qobuz API (no failover needed as there's only one)
+    private const string QobuzBaseUrl = "https://qobuz.squid.wtf";
+    
+    // Instance state - shared across all requests during app lifetime
+    private List<string>? _tidalInstances;
+    private int _currentInstanceIndex;
+    private string? _currentTidalInstance;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized;
+    
+    public int TimeoutSeconds { get; }
+    
+    public SquidWTFInstanceManager(
+        IHttpClientFactory httpClientFactory,
+        IOptions<SquidWTFSettings> settings,
+        ILogger<SquidWTFInstanceManager> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _settings = settings.Value;
+        _logger = logger;
+        
+        // Use configured timeout or default
+        TimeoutSeconds = _settings.InstanceTimeoutSeconds > 0 
+            ? _settings.InstanceTimeoutSeconds 
+            : DefaultTimeoutSeconds;
+    }
+    
+    /// <summary>
+    /// Gets the base URL for the current source (Qobuz or Tidal)
+    /// For Tidal, returns the currently active instance
+    /// </summary>
+    public async Task<string> GetBaseUrlAsync()
+    {
+        if (_settings.Source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase))
+        {
+            return QobuzBaseUrl;
+        }
+        
+        await EnsureInitializedAsync();
+        return _currentTidalInstance ?? throw new InvalidOperationException("No Tidal instance available");
+    }
+    
+    /// <summary>
+    /// Sends an HTTP request with automatic failover to next instance on timeout
+    /// </summary>
+    public async Task<HttpResponseMessage> SendWithFailoverAsync(
+        Func<string, HttpRequestMessage> createRequest,
+        CancellationToken cancellationToken = default)
+    {
+        var baseUrl = await GetBaseUrlAsync();
+        
+        // For Qobuz, just send the request (no failover)
+        if (_settings.Source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase))
+        {
+            var request = createRequest(baseUrl);
+            return await _httpClient.SendAsync(request, cancellationToken);
+        }
+        
+        // For Tidal, try with failover
+        var attemptedInstances = new HashSet<string>();
+        
+        while (attemptedInstances.Count < (_tidalInstances?.Count ?? 1))
+        {
+            var currentUrl = _currentTidalInstance!;
+            attemptedInstances.Add(currentUrl);
+            
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(TimeoutSeconds));
+                
+                var request = createRequest(currentUrl);
+                var response = await _httpClient.SendAsync(request, cts.Token);
+                
+                // Success - this instance works
+                return response;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Timeout - switch to next instance
+                _logger.LogWarning("Tidal instance {Instance} timed out after {Timeout}s, switching to next...", 
+                    currentUrl, TimeoutSeconds);
+                SwitchToNextInstance();
+            }
+            catch (HttpRequestException ex)
+            {
+                // Network error - switch to next instance
+                _logger.LogWarning(ex, "Tidal instance {Instance} failed, switching to next...", currentUrl);
+                SwitchToNextInstance();
+            }
+        }
+        
+        throw new InvalidOperationException("All Tidal instances failed or timed out");
+    }
+    
+    /// <summary>
+    /// Marks the current instance as slow/failed and switches to the next one
+    /// </summary>
+    public void SwitchToNextInstance()
+    {
+        if (_tidalInstances == null || _tidalInstances.Count <= 1)
+        {
+            _logger.LogWarning("Cannot switch instance: only one instance available");
+            return;
+        }
+        
+        var previousInstance = _currentTidalInstance;
+        _currentInstanceIndex = (_currentInstanceIndex + 1) % _tidalInstances.Count;
+        _currentTidalInstance = _tidalInstances[_currentInstanceIndex];
+        
+        _logger.LogInformation("Switched Tidal instance from {Previous} to {Current}", 
+            previousInstance, _currentTidalInstance);
+    }
+    
+    /// <summary>
+    /// Gets the currently active Tidal instance URL (for logging/debugging)
+    /// </summary>
+    public string? GetCurrentInstance() => _currentTidalInstance;
+    
+    private async Task EnsureInitializedAsync()
+    {
+        if (_initialized) return;
+        
+        await _initLock.WaitAsync();
+        try
+        {
+            if (_initialized) return;
+            
+            await LoadInstancesAsync();
+            _initialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+    
+    private async Task LoadInstancesAsync()
+    {
+        try
+        {
+            _logger.LogInformation("Loading SquidWTF instances from {Url}", InstancesJsonUrl);
+            
+            var response = await _httpClient.GetStringAsync(InstancesJsonUrl);
+            var instances = JsonSerializer.Deserialize<InstancesJson>(response);
+            
+            if (instances?.Api == null || instances.Api.Count == 0)
+            {
+                throw new InvalidOperationException("No API instances found in instances.json");
+            }
+            
+            // Normalize URLs (remove trailing slashes)
+            _tidalInstances = instances.Api
+                .Select(url => url.TrimEnd('/'))
+                .ToList();
+            
+            _currentInstanceIndex = 0;
+            _currentTidalInstance = _tidalInstances[0];
+            
+            _logger.LogInformation("Loaded {Count} Tidal instances, starting with {Instance}", 
+                _tidalInstances.Count, _currentTidalInstance);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load instances from remote JSON, using fallback");
+            
+            // Fallback to hardcoded instance
+            _tidalInstances = new List<string> { "https://tidal-api.binimum.org" };
+            _currentInstanceIndex = 0;
+            _currentTidalInstance = _tidalInstances[0];
+        }
+    }
+    
+    private class InstancesJson
+    {
+        [JsonPropertyName("api")]
+        public List<string>? Api { get; set; }
+        
+        [JsonPropertyName("streaming")]
+        public List<string>? Streaming { get; set; }
+    }
+}

--- a/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using octo_fiesta.Models.Settings;
@@ -12,19 +11,25 @@ namespace octo_fiesta.Services.SquidWTF;
 public class SquidWTFStartupValidator : BaseStartupValidator
 {
     private readonly SquidWTFSettings _settings;
+    private readonly SquidWTFInstanceManager? _instanceManager;
 
     public override string ServiceName => "SquidWTF";
 
-    public SquidWTFStartupValidator(IOptions<SquidWTFSettings> settings, HttpClient httpClient)
+    public SquidWTFStartupValidator(
+        IOptions<SquidWTFSettings> settings, 
+        HttpClient httpClient,
+        IServiceProvider serviceProvider)
         : base(httpClient)
     {
         _settings = settings.Value;
+        _instanceManager = serviceProvider.GetService<SquidWTFInstanceManager>();
     }
 
     public override async Task<ValidationResult> ValidateAsync(CancellationToken cancellationToken)
     {
         Console.WriteLine();
 
+        var source = _settings.Source ?? "Qobuz";
         var quality = _settings.Quality?.ToUpperInvariant() switch
         {
             "FLAC" => "LOSSLESS",
@@ -32,31 +37,32 @@ public class SquidWTFStartupValidator : BaseStartupValidator
             "LOSSLESS" => "LOSSLESS",
             "HIGH" => "HIGH",
             "LOW" => "LOW",
-            _ => "LOSSLESS (default)"
+            "27" => "FLAC 24-bit/192kHz",
+            "7" => "FLAC 24-bit/96kHz",
+            "6" => "FLAC 16-bit",
+            "5" => "MP3 320kbps",
+            _ => source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase) 
+                ? "FLAC 24-bit/192kHz (default)" 
+                : "LOSSLESS (default)"
         };
 
+        WriteStatus("SquidWTF Source", source, ConsoleColor.Cyan);
         WriteStatus("SquidWTF Quality", quality, ConsoleColor.Cyan);
+        
+        if (_settings.InstanceTimeoutSeconds > 0)
+        {
+            WriteStatus("Instance Timeout", $"{_settings.InstanceTimeoutSeconds}s", ConsoleColor.Cyan);
+        }
 
-        // Test connectivity to triton.squid.wtf
         try
         {
-            var response = await _httpClient.GetAsync("https://tidal-api.binimum.org/", cancellationToken);
-
-            if (response.IsSuccessStatusCode)
+            if (source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase))
             {
-                WriteStatus("SquidWTF API", "REACHABLE", ConsoleColor.Green);
-                WriteDetail("No authentication required - powered by Tidal");
-                
-                // Try a test search to verify functionality
-                await ValidateSearchFunctionality(cancellationToken);
-                
-                return ValidationResult.Success("SquidWTF validation completed");
+                return await ValidateQobuzAsync(cancellationToken);
             }
             else
             {
-                WriteStatus("SquidWTF API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
-                WriteDetail("Service may be temporarily unavailable");
-			return ValidationResult.Failure($"{response.StatusCode}", "SquidWTF returned code");
+                return await ValidateTidalAsync(cancellationToken);
             }
         }
         catch (TaskCanceledException)
@@ -79,34 +85,106 @@ public class SquidWTFStartupValidator : BaseStartupValidator
         }
     }
 
+    private async Task<ValidationResult> ValidateQobuzAsync(CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync("https://qobuz.squid.wtf/api/get-music?q=test&offset=0", cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            WriteStatus("SquidWTF API", "REACHABLE", ConsoleColor.Green);
+            WriteDetail("No authentication required - powered by Qobuz");
+            return ValidationResult.Success("SquidWTF Qobuz validation completed");
+        }
+        else
+        {
+            WriteStatus("SquidWTF API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
+            WriteDetail("Service may be temporarily unavailable");
+            return ValidationResult.Failure($"{response.StatusCode}", "SquidWTF returned code");
+        }
+    }
+
+    private async Task<ValidationResult> ValidateTidalAsync(CancellationToken cancellationToken)
+    {
+        if (_instanceManager != null)
+        {
+            // Use instance manager to test with failover
+            var response = await _instanceManager.SendWithFailoverAsync(baseUrl =>
+            {
+                return new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/search/?s=test");
+            }, cancellationToken);
+
+            var currentInstance = _instanceManager.GetCurrentInstance();
+            
+            if (response.IsSuccessStatusCode)
+            {
+                WriteStatus("SquidWTF API", "REACHABLE", ConsoleColor.Green);
+                WriteStatus("Active Instance", currentInstance ?? "unknown", ConsoleColor.Cyan);
+                WriteDetail("No authentication required - powered by Tidal");
+                
+                // Try a test search to verify functionality
+                await ValidateSearchFunctionality(cancellationToken);
+                
+                return ValidationResult.Success("SquidWTF Tidal validation completed");
+            }
+            else
+            {
+                WriteStatus("SquidWTF API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
+                WriteDetail("Service may be temporarily unavailable");
+                return ValidationResult.Failure($"{response.StatusCode}", "SquidWTF returned code");
+            }
+        }
+        else
+        {
+            // Fallback if instance manager not available
+            var response = await _httpClient.GetAsync("https://tidal-api.binimum.org/", cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                WriteStatus("SquidWTF API", "REACHABLE", ConsoleColor.Green);
+                WriteDetail("No authentication required - powered by Tidal");
+                return ValidationResult.Success("SquidWTF Tidal validation completed");
+            }
+            else
+            {
+                WriteStatus("SquidWTF API", $"HTTP {(int)response.StatusCode}", ConsoleColor.Yellow);
+                WriteDetail("Service may be temporarily unavailable");
+                return ValidationResult.Failure($"{response.StatusCode}", "SquidWTF returned code");
+            }
+        }
+    }
+
     private async Task ValidateSearchFunctionality(CancellationToken cancellationToken)
     {
         try
         {
-            // Test search with a simple query
-            var searchUrl = "https://tidal-api.binimum.org/search/?s=Taylor%20Swift";
-            var searchResponse = await _httpClient.GetAsync(searchUrl, cancellationToken);
-
-            if (searchResponse.IsSuccessStatusCode)
+            if (_instanceManager != null)
             {
-                var json = await searchResponse.Content.ReadAsStringAsync(cancellationToken);
-                var doc = JsonDocument.Parse(json);
-                
-                if (doc.RootElement.TryGetProperty("data", out var data) &&
-                    data.TryGetProperty("items", out var items))
+                var searchResponse = await _instanceManager.SendWithFailoverAsync(baseUrl =>
                 {
-                    var itemCount = items.GetArrayLength();
-                    WriteStatus("Search Functionality", "WORKING", ConsoleColor.Green);
-                    WriteDetail($"Test search returned {itemCount} results");
+                    return new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/search/?s=Taylor%20Swift");
+                }, cancellationToken);
+
+                if (searchResponse.IsSuccessStatusCode)
+                {
+                    var json = await searchResponse.Content.ReadAsStringAsync(cancellationToken);
+                    var doc = JsonDocument.Parse(json);
+                    
+                    if (doc.RootElement.TryGetProperty("data", out var data) &&
+                        data.TryGetProperty("items", out var items))
+                    {
+                        var itemCount = items.GetArrayLength();
+                        WriteStatus("Search Functionality", "WORKING", ConsoleColor.Green);
+                        WriteDetail($"Test search returned {itemCount} results");
+                    }
+                    else
+                    {
+                        WriteStatus("Search Functionality", "UNEXPECTED RESPONSE", ConsoleColor.Yellow);
+                    }
                 }
                 else
                 {
-                    WriteStatus("Search Functionality", "UNEXPECTED RESPONSE", ConsoleColor.Yellow);
+                    WriteStatus("Search Functionality", $"HTTP {(int)searchResponse.StatusCode}", ConsoleColor.Yellow);
                 }
-            }
-            else
-            {
-                WriteStatus("Search Functionality", $"HTTP {(int)searchResponse.StatusCode}", ConsoleColor.Yellow);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Add automatic API instance failover for SquidWTF Tidal backend, if an instance doesn't respond within the configured timeout, automatically switches to the next available instance
- Instance list is fetched from the community-maintained registry at startup and the working instance is kept for the application lifetime