### PR TITLE
fix: update .env.example and docker-compose with complete SquidWTF quality options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,8 @@ QOBUZ_QUALITY=
 SQUIDWTF_SOURCE=Qobuz
 
 # Preferred audio quality (optional)
-# For Qobuz backend: 27 (FLAC 24-bit), 7 (FLAC 16-bit), 6 (MP3 320), 5 (MP3 128)
-# For Tidal backend: HI_RES_LOSSLESS, LOSSLESS
+# For Qobuz backend: 27 (FLAC 24-bit/192kHz), 7 (FLAC 24-bit/96kHz), 6 (FLAC 16-bit/44kHz), 5 (MP3 320kbps)
+# For Tidal backend: HI_RES_LOSSLESS (FLAC 24-bit/192kHz), LOSSLESS (FLAC 16-bit/44kHz), HIGH (AAC 320kbps), LOW (AAC 96kbps)
 # If not specified, the highest available quality will be used
 SQUIDWTF_QUALITY=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
       # Backend source: Qobuz or Tidal (default: Qobuz)
       - SquidWTF__Source=${SQUIDWTF_SOURCE:-Qobuz}
       # Preferred audio quality (optional)
-      # Qobuz: 27 (FLAC 24-bit), 7 (FLAC 16-bit), 6 (MP3 320), 5 (MP3 128)
-      # Tidal: HI_RES_LOSSLESS, LOSSLESS
+      # Qobuz: 27 (FLAC 24-bit/192kHz), 7 (FLAC 24-bit/96kHz), 6 (FLAC 16-bit/44kHz), 5 (MP3 320kbps)
+      # Tidal: HI_RES_LOSSLESS (FLAC 24-bit/192kHz), LOSSLESS (FLAC 16-bit/44kHz), HIGH (AAC 320kbps), LOW (AAC 96kbps)
       - SquidWTF__Quality=${SQUIDWTF_QUALITY:-}
       # Instance timeout in seconds for Tidal backend (default: 5)
       # Switches to next instance if current one doesn't respond in time


### PR DESCRIPTION
This PR updates the example documentation for the changes already made to the SquidWTF quality options for both backends.

In addition, the Configuration wiki page section for SquidWTF Quality Options needs to be updated to match to complete the change.

Also addresses #102 