### PR TITLE
fix: Using Deezer's private API to fix the account vs server country issue

### DIFF
--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -275,6 +275,13 @@ public class DeezerDownloadService : BaseDownloadService
 
             var trackToken = trackTokenElement.GetString();
 
+            var pageData = await GetTrackPageDataAsync(decryptionTrackId, arl, cancellationToken);
+            if (!string.IsNullOrEmpty(pageData?.TrackToken))
+            {
+                Logger.LogInformation("Using session-bound TRACK_TOKEN from private API for track {TrackId}", decryptionTrackId);
+                trackToken = pageData.TrackToken;
+            }
+
             // Get download URL via media API
             // Build format list based on preferred quality
             var formatsList = BuildFormatsList(_preferredQuality);


### PR DESCRIPTION
Hi! I've dropped a quick fix that should address #81. 
Now the downloader service does use Deezer's private API for trackToken (the same used in the app and browser) while keeping the public one as a fallback.