### PR TITLE
Platform-specific invalid character handling for cross-platform filename sanitization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ SUBSONIC_URL=http://localhost:4533
 # Path where downloaded songs will be stored on the host (only applies if STORAGE_MODE=Permanent)
 DOWNLOAD_PATH=./downloads
 
+# Operating system format for filename sanitization (optional)
+# Set to "Windows" if files will be accessed from Windows, "Unix" for Linux/macOS
+# When empty, uses the current container OS
+# Example: Use "Windows" in Docker on Linux to create Windows-compatible filenames
+LIBRARY_FORMATTING_FILENAME_OS=
+
 # Music service to use: Deezer, Qobuz, or SquidWTF (default: SquidWTF)
 MUSIC_SERVICE=SquidWTF
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       # Download path inside container
       - Library__DownloadPath=/app/downloads
+      # OS format for filename sanitization: Windows, Unix, or empty (default: container OS)
+      - Library__FormattingFilenameOS=${LIBRARY_FORMATTING_FILENAME_OS:-}
       
       # ===== SUBSONIC SETTINGS =====
       # Navidrome/Subsonic server URL

--- a/octo-fiesta.Tests/PathHelperTests.cs
+++ b/octo-fiesta.Tests/PathHelperTests.cs
@@ -1,0 +1,327 @@
+using octo_fiesta.Services.Common;
+using Xunit;
+
+namespace octo_fiesta.Tests;
+
+public class PathHelperUnitTests
+{
+    #region GetInvalidFileNameChars Tests
+
+    [Fact]
+    public void GetInvalidFileNameChars_WithNull_ReturnsCurrentOSChars()
+    {
+        var result = PathHelper.GetInvalidFileNameChars(null);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void GetInvalidFileNameChars_WithWindows_ReturnsWindowsChars()
+    {
+        var result = PathHelper.GetInvalidFileNameChars("Windows");
+        Assert.Contains('"', result);
+        Assert.Contains('<', result);
+        Assert.Contains('>', result);
+        Assert.Contains('|', result);
+        Assert.Contains(':', result);
+        Assert.Contains('*', result);
+        Assert.Contains('?', result);
+        Assert.Contains('\\', result);
+        Assert.Contains('/', result);
+    }
+
+    [Fact]
+    public void GetInvalidFileNameChars_WithUnix_ReturnsUnixChars()
+    {
+        var result = PathHelper.GetInvalidFileNameChars("Unix");
+        Assert.Equal(2, result.Length);
+        Assert.Contains('\0', result);
+        Assert.Contains('/', result);
+    }
+
+    [Fact]
+    public void GetInvalidFileNameChars_WithEmptyString_ReturnsCurrentOSChars()
+    {
+        var result = PathHelper.GetInvalidFileNameChars("");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+    }
+
+    #endregion
+
+    #region GetInvalidPathChars Tests
+
+    [Fact]
+    public void GetInvalidPathChars_WithNull_ReturnsCurrentOSChars()
+    {
+        var result = PathHelper.GetInvalidPathChars(null);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void GetInvalidPathChars_WithWindows_ReturnsWindowsChars()
+    {
+        var result = PathHelper.GetInvalidPathChars("Windows");
+        Assert.Contains('|', result);
+        Assert.DoesNotContain(':', result);
+        Assert.DoesNotContain('*', result);
+        Assert.DoesNotContain('?', result);
+    }
+
+    [Fact]
+    public void GetInvalidPathChars_WithUnix_ReturnsUnixChars()
+    {
+        var result = PathHelper.GetInvalidPathChars("Unix");
+        Assert.Single(result);
+        Assert.Contains('\0', result);
+    }
+
+    [Fact]
+    public void GetInvalidPathChars_WithEmptyString_ReturnsCurrentOSChars()
+    {
+        var result = PathHelper.GetInvalidPathChars("");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+    }
+
+    #endregion
+
+    #region GetCachePath Tests
+
+    [Fact]
+    public void GetCachePath_ReturnsPathWithCacheSubfolder()
+    {
+        var result = PathHelper.GetCachePath();
+        Assert.EndsWith("octo-fiesta-cache", result);
+    }
+
+    [Fact]
+    public void GetCachePath_ReturnsAbsolutePath()
+    {
+        var result = PathHelper.GetCachePath();
+        Assert.True(Path.IsPathRooted(result));
+    }
+
+    #endregion
+
+    #region BuildTrackPath Tests
+
+    [Fact]
+    public void BuildTrackPath_WithValidInputs_ReturnsCorrectPath()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song", 5, ".flac");
+        Assert.EndsWith("Artist/Album/05 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithoutTrackNumber_ReturnsPathWithoutPrefix()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song", null, ".mp3");
+        Assert.EndsWith("Artist/Album/Song.mp3", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithSpecialCharacters_SanitizesNames()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song/Name", 1, ".flac");
+        var fileName = Path.GetFileName(result);
+        Assert.DoesNotContain("/", fileName);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithNullTrackNumber_SanitizesFolderNames()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song", null, ".flac");
+        Assert.Contains("Artist", result);
+        Assert.Contains("Album", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithExtensionWithoutDot_AddsDot()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song", 1, "flac");
+        Assert.EndsWith(".flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithEmptyExtension_ReturnsNoDot()
+    {
+        var result = PathHelper.BuildTrackPath("/music", "Artist", "Album", "Song", 1, "");
+        Assert.EndsWith("Song", result);
+    }
+
+    #endregion
+
+    #region SanitizeFileName Tests
+
+    [Fact]
+    public void SanitizeFileName_WithValidName_ReturnsSameName()
+    {
+        var result = PathHelper.SanitizeFileName("Valid Song Name");
+        Assert.Equal("Valid Song Name", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithWindows_ReplacesWindowsInvalidChars()
+    {
+        var result = PathHelper.SanitizeFileName("Song:Name?Test<File>Name", "Windows");
+        Assert.DoesNotContain(":", result);
+        Assert.DoesNotContain("?", result);
+        Assert.DoesNotContain("<", result);
+        Assert.DoesNotContain(">", result);
+        Assert.Contains("_", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithUnix_ReplacesUnixInvalidChars()
+    {
+        var result = PathHelper.SanitizeFileName("Song/Name", "Unix");
+        Assert.DoesNotContain("/", result);
+        Assert.Contains("_", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithLongName_TruncatesTo100Chars()
+    {
+        var longName = new string('a', 150);
+        var result = PathHelper.SanitizeFileName(longName);
+        Assert.Equal(100, result.Length);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithLeadingTrailingSpaces_Trims()
+    {
+        var result = PathHelper.SanitizeFileName("  Song Name  ");
+        Assert.Equal("Song Name", result);
+    }
+
+    #endregion
+
+    #region SanitizeFolderName Tests
+
+    [Fact]
+    public void SanitizeFolderName_WithValidName_ReturnsSameName()
+    {
+        var result = PathHelper.SanitizeFolderName("Valid Folder");
+        Assert.Equal("Valid Folder", result);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithWindows_ReplacesInvalidChars()
+    {
+        var result = PathHelper.SanitizeFolderName("Folder:Name?Test<File>|Name", "Windows");
+        Assert.DoesNotContain(":", result);
+        Assert.DoesNotContain("?", result);
+        Assert.DoesNotContain("<", result);
+        Assert.DoesNotContain(">", result);
+        Assert.DoesNotContain("|", result);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithUnix_ReplacesInvalidChars()
+    {
+        var result = PathHelper.SanitizeFolderName("Folder/Name", "Unix");
+        Assert.DoesNotContain("/", result);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithLongName_TruncatesTo100Chars()
+    {
+        var longName = new string('a', 150);
+        var result = PathHelper.SanitizeFolderName(longName);
+        Assert.Equal(100, result.Length);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithLeadingTrailingDots_Trims()
+    {
+        var result = PathHelper.SanitizeFolderName("...FolderName...");
+        Assert.False(result.StartsWith("."));
+        Assert.False(result.EndsWith("."));
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithLeadingTrailingSpaces_Trims()
+    {
+        var result = PathHelper.SanitizeFolderName("  FolderName  ");
+        Assert.Equal("FolderName", result);
+    }
+
+    #endregion
+
+    #region ResolveUniquePath Tests
+
+    [Fact]
+    public void ResolveUniquePath_WithNonExistingPath_ReturnsSamePath()
+    {
+        var result = PathHelper.ResolveUniquePath("/nonexistent/path/song.flac");
+        Assert.Equal("/nonexistent/path/song.flac", result);
+    }
+
+    [Fact]
+    public void ResolveUniquePath_WithExistingPath_AppendsCounter()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.txt");
+        try
+        {
+            File.WriteAllText(tempFile, "test");
+            var result = PathHelper.ResolveUniquePath(tempFile);
+            Assert.NotEqual(tempFile, result);
+            Assert.Contains("(1)", result);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ResolveUniquePath_WithMultipleExistingPaths_IncrementsCounter()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.txt");
+        var tempFile2 = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.txt");
+        try
+        {
+            File.WriteAllText(tempFile, "test");
+            File.WriteAllText(tempFile2, "test");
+            var result = PathHelper.ResolveUniquePath(tempFile);
+            Assert.Contains("(1)", result);
+            Assert.DoesNotContain("(2)", result);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+            if (File.Exists(tempFile2))
+                File.Delete(tempFile2);
+        }
+    }
+
+    #endregion
+
+    #region OsFormat Parameter Tests
+
+    [Fact]
+    public void SanitizeFileName_PassesOsFormatToGetInvalidFileNameChars()
+    {
+        var windowsResult = PathHelper.SanitizeFileName("a:b", "Windows");
+        var unixResult = PathHelper.SanitizeFileName("a:b", "Unix");
+        
+        Assert.DoesNotContain(":", windowsResult);
+        Assert.Contains(":", unixResult);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_PassesOsFormatToInvalidCharsMethods()
+    {
+        var windowsResult = PathHelper.SanitizeFolderName("a:b", "Windows");
+        var unixResult = PathHelper.SanitizeFolderName("a:b", "Unix");
+        
+        Assert.DoesNotContain(":", windowsResult);
+        Assert.Contains(":", unixResult);
+    }
+
+    #endregion
+}

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -27,6 +27,7 @@ public abstract class BaseDownloadService : IDownloadService
 
     protected readonly string DownloadPath;
     protected readonly string CachePath;
+    protected readonly string? FormattingFilenameOS;
 
     protected readonly Dictionary<string, DownloadInfo> ActiveDownloads = new();
     protected readonly SemaphoreSlim DownloadLock = new(1, 1);
@@ -81,6 +82,7 @@ public abstract class BaseDownloadService : IDownloadService
         Logger = logger;
 
         DownloadPath = configuration["Library:DownloadPath"] ?? "./downloads";
+        FormattingFilenameOS = configuration["Library:FormattingFilenameOS"];
         CachePath = PathHelper.GetCachePath();
 
         if (!Directory.Exists(DownloadPath))
@@ -829,9 +831,9 @@ public abstract class BaseDownloadService : IDownloadService
             }
 
             var artistForPath = song.AlbumArtist ?? song.Artist;
-            var safeArtist = PathHelper.SanitizeFolderName(artistForPath);
-            var safeAlbum = PathHelper.SanitizeFolderName(song.Album);
-            var safeTitle = PathHelper.SanitizeFileName(song.Title);
+            var safeArtist = PathHelper.SanitizeFolderName(artistForPath, FormattingFilenameOS);
+            var safeAlbum = PathHelper.SanitizeFolderName(song.Album, FormattingFilenameOS);
+            var safeTitle = PathHelper.SanitizeFileName(song.Title, FormattingFilenameOS);
 
             var albumFolder = Path.Combine(CachePath, safeArtist, safeAlbum);
             if (!Directory.Exists(albumFolder))

--- a/octo-fiesta/Services/Common/PathHelper.cs
+++ b/octo-fiesta/Services/Common/PathHelper.cs
@@ -75,12 +75,13 @@ public static class PathHelper
     /// <param name="title">Track title (will be sanitized).</param>
     /// <param name="trackNumber">Optional track number for prefix.</param>
     /// <param name="extension">File extension (e.g., ".flac", ".mp3").</param>
+    /// <param name="OsFormat">The operating system format to use. If null, the current operating system is used.</param>
     /// <returns>Full path for the track file.</returns>
-    public static string BuildTrackPath(string downloadPath, string artist, string album, string title, int? trackNumber, string extension)
+    public static string BuildTrackPath(string downloadPath, string artist, string album, string title, int? trackNumber, string extension, string? OsFormat = null)
     {
-        var safeArtist = SanitizeFolderName(artist);
-        var safeAlbum = SanitizeFolderName(album);
-        var safeTitle = SanitizeFileName(title);
+        var safeArtist = SanitizeFolderName(artist, OsFormat);
+        var safeAlbum = SanitizeFolderName(album, OsFormat);
+        var safeTitle = SanitizeFileName(title, OsFormat);
 
         var artistFolder = Path.Combine(downloadPath, safeArtist);
         var albumFolder = Path.Combine(artistFolder, safeAlbum);

--- a/octo-fiesta/Services/Common/PathHelper.cs
+++ b/octo-fiesta/Services/Common/PathHelper.cs
@@ -32,9 +32,9 @@ public static class PathHelper
 
     private static char[] InvalidPathCharsUnix => new char[] { '\0' };
 
-    public static char[] GetInvalidFileNameChars()
+    public static char[] GetInvalidFileNameChars(string? OsFormat = null)
     {
-        return Environment.GetEnvironmentVariable("FORMATTING_FILENAME_OS") switch
+        return OsFormat switch
         {
             "Windows" => InvalidFileNameCharsWindows,
             "Unix" => InvalidFileNameCharsUnix,
@@ -42,9 +42,9 @@ public static class PathHelper
         };
     }
 
-    public static char[] GetInvalidPathChars()
+    public static char[] GetInvalidPathChars(string? OsFormat = null)
     {
-        return Environment.GetEnvironmentVariable("FORMATTING_FILENAME_OS") switch
+        return OsFormat switch
         {
             "Windows" => InvalidPathCharsWindows,
             "Unix" => InvalidPathCharsUnix,
@@ -95,15 +95,16 @@ public static class PathHelper
     /// Sanitizes a file name by removing invalid characters.
     /// </summary>
     /// <param name="fileName">Original file name.</param>
+    /// <param name="OsFormat">The operating system format to use. If null, the current operating system is used.</param>
     /// <returns>Sanitized file name safe for all file systems.</returns>
-    public static string SanitizeFileName(string fileName)
+    public static string SanitizeFileName(string fileName, string? OsFormat = null)
     {
         if (string.IsNullOrWhiteSpace(fileName))
         {
             return "Unknown";
         }
 
-        var invalidChars = PathHelper.GetInvalidFileNameChars();
+        var invalidChars = PathHelper.GetInvalidFileNameChars(OsFormat);
         var sanitized = new string(fileName
             .Select(c => invalidChars.Contains(c) ? '_' : c)
             .ToArray());
@@ -120,16 +121,17 @@ public static class PathHelper
     /// Sanitizes a folder name by removing invalid path characters.
     /// </summary>
     /// <param name="folderName">Original folder name.</param>
+    /// <param name="OsFormat">The operating system format to use. If null, the current operating system is used.</param>
     /// <returns>Sanitized folder name safe for all file systems.</returns>
-    public static string SanitizeFolderName(string folderName)
+    public static string SanitizeFolderName(string folderName, string? OsFormat = null)
     {
         if (string.IsNullOrWhiteSpace(folderName))
         {
             return "Unknown";
         }
 
-        var invalidChars = PathHelper.GetInvalidFileNameChars()
-            .Concat(PathHelper.GetInvalidPathChars())
+        var invalidChars = PathHelper.GetInvalidFileNameChars(OsFormat)
+            .Concat(PathHelper.GetInvalidPathChars(OsFormat))
             .Distinct()
             .ToArray();
 

--- a/octo-fiesta/Services/Common/PathHelper.cs
+++ b/octo-fiesta/Services/Common/PathHelper.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using IOFile = System.IO.File;
 
 namespace octo_fiesta.Services.Common;
@@ -8,6 +9,52 @@ namespace octo_fiesta.Services.Common;
 /// </summary>
 public static class PathHelper
 {
+    private static char[] InvalidFileNameCharsWindows =>
+    [
+        '\"', '<', '>', '|', '\0',
+        (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+        (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+        (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+        (char)31, ':', '*', '?', '\\', '/'
+    ];
+
+    private static char[] InvalidPathCharsWindows =>
+    [
+        '|', '\0',
+        (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+        (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+        (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+        (char)31
+    ];
+
+
+    private static char[] InvalidFileNameCharsUnix => new char[] { '\0', '/' };
+
+    private static char[] InvalidPathCharsUnix => new char[] { '\0' };
+
+    public static char[] GetInvalidFileNameChars()
+    {
+        return Environment.GetEnvironmentVariable("FORMATTING_FILENAME_OS") switch
+        {
+            "Windows" => InvalidFileNameCharsWindows,
+            "Unix" => InvalidFileNameCharsUnix,
+            _ => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? InvalidFileNameCharsWindows : InvalidFileNameCharsUnix
+        };
+    }
+
+    public static char[] GetInvalidPathChars()
+    {
+        return Environment.GetEnvironmentVariable("FORMATTING_FILENAME_OS") switch
+        {
+            "Windows" => InvalidPathCharsWindows,
+            "Unix" => InvalidPathCharsUnix,
+            _ => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? InvalidPathCharsWindows : InvalidPathCharsUnix
+        };
+    }
+
+
+
+
     /// <summary>
     /// Gets the cache directory path for temporary file storage.
     /// Uses system temp directory combined with octo-fiesta-cache subfolder.
@@ -18,7 +65,7 @@ public static class PathHelper
     {
         return Path.Combine(Path.GetTempPath(), "octo-fiesta-cache");
     }
-    
+
     /// <summary>
     /// Builds the output path for a downloaded track following the Artist/Album/Track structure.
     /// </summary>
@@ -34,13 +81,13 @@ public static class PathHelper
         var safeArtist = SanitizeFolderName(artist);
         var safeAlbum = SanitizeFolderName(album);
         var safeTitle = SanitizeFileName(title);
-        
+
         var artistFolder = Path.Combine(downloadPath, safeArtist);
         var albumFolder = Path.Combine(artistFolder, safeAlbum);
-        
+
         var trackPrefix = trackNumber.HasValue ? $"{trackNumber:D2} - " : "";
         var fileName = $"{trackPrefix}{safeTitle}{extension}";
-        
+
         return Path.Combine(albumFolder, fileName);
     }
 
@@ -55,17 +102,17 @@ public static class PathHelper
         {
             return "Unknown";
         }
-        
-        var invalidChars = Path.GetInvalidFileNameChars();
+
+        var invalidChars = PathHelper.GetInvalidFileNameChars();
         var sanitized = new string(fileName
             .Select(c => invalidChars.Contains(c) ? '_' : c)
             .ToArray());
-        
+
         if (sanitized.Length > 100)
         {
             sanitized = sanitized[..100];
         }
-        
+
         return sanitized.Trim();
     }
 
@@ -80,30 +127,30 @@ public static class PathHelper
         {
             return "Unknown";
         }
-        
-        var invalidChars = Path.GetInvalidFileNameChars()
-            .Concat(Path.GetInvalidPathChars())
+
+        var invalidChars = PathHelper.GetInvalidFileNameChars()
+            .Concat(PathHelper.GetInvalidPathChars())
             .Distinct()
             .ToArray();
-            
+
         var sanitized = new string(folderName
             .Select(c => invalidChars.Contains(c) ? '_' : c)
             .ToArray());
-        
+
         // Remove leading/trailing dots and spaces (Windows folder restrictions)
         sanitized = sanitized.Trim().TrimEnd('.');
-        
+
         if (sanitized.Length > 100)
         {
             sanitized = sanitized[..100].TrimEnd('.');
         }
-        
+
         // Ensure we have a valid name
         if (string.IsNullOrWhiteSpace(sanitized))
         {
             return "Unknown";
         }
-        
+
         return sanitized;
     }
 
@@ -118,11 +165,11 @@ public static class PathHelper
         {
             return basePath;
         }
-        
+
         var directory = Path.GetDirectoryName(basePath)!;
         var extension = Path.GetExtension(basePath);
         var fileNameWithoutExt = Path.GetFileNameWithoutExtension(basePath);
-        
+
         var counter = 1;
         string uniquePath;
         do
@@ -130,7 +177,7 @@ public static class PathHelper
             uniquePath = Path.Combine(directory, $"{fileNameWithoutExt} ({counter}){extension}");
             counter++;
         } while (IOFile.Exists(uniquePath));
-        
+
         return uniquePath;
     }
 }

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -123,7 +123,7 @@ public class DeezerDownloadService : BaseDownloadService
         // Build organized folder structure: Artist/Album/Track using AlbumArtist (fallback to Artist for singles)
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension, FormattingFilenameOS);
         
         // Create directories if they don't exist
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -123,7 +123,7 @@ public class QobuzDownloadService : BaseDownloadService
         // Build organized folder structure using AlbumArtist (fallback to Artist for singles)
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension, FormattingFilenameOS);
         
         var albumFolder = Path.GetDirectoryName(outputPath)!;
         EnsureDirectoryExists(albumFolder);

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -164,7 +164,7 @@ public class SquidWTFDownloadService : BaseDownloadService
         // Build output path
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension, FormattingFilenameOS);
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;
@@ -227,7 +227,7 @@ public class SquidWTFDownloadService : BaseDownloadService
         // Build output path
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension, FormattingFilenameOS);
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/appsettings.json
+++ b/octo-fiesta/appsettings.json
@@ -16,7 +16,8 @@
     "CacheDurationHours": 1
   },
   "Library": {
-    "DownloadPath": "./downloads"
+    "DownloadPath": "./downloads",
+    "FormattingFilenameOS": ""
   },
   "Deezer": {
     "Arl": "",


### PR DESCRIPTION
Hello,
this is a first attempt to fix issue #133

Left todo:
- [x] Edit .env.example
- [x] Edit docker-compose
- [x] Add tests
- [ ] Update the Wiki
- [x] Use `IConfiguration` to pass the config instead of the `FORMATTING_FILENAME_OS` env var