### PR TITLE
Fix: CoverArtUrlLarge not being used and improving deezer artist and playlist art quality

### DIFF
--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -612,7 +612,7 @@ public class SubsonicController : ControllerBase
                 var album = await _metadataService.GetAlbumAsync(coverProvider!, coverExternalId!);
                 if (album?.CoverArtUrl != null)
                 {
-                    coverUrl = album.CoverArtUrl;
+                    coverUrl = album.CoverArtUrlLarge ?? album.CoverArtUrl;
                 }
                 break;
                 
@@ -622,7 +622,7 @@ public class SubsonicController : ControllerBase
                 var song = await _metadataService.GetSongAsync(coverProvider!, coverExternalId!);
                 if (song?.CoverArtUrl != null)
                 {
-                    coverUrl = song.CoverArtUrl;
+                    coverUrl = song.CoverArtUrlLarge ?? song.CoverArtUrl;
                 }
                 else
                 {
@@ -630,7 +630,7 @@ public class SubsonicController : ControllerBase
                     var albumFallback = await _metadataService.GetAlbumAsync(coverProvider!, coverExternalId!);
                     if (albumFallback?.CoverArtUrl != null)
                     {
-                        coverUrl = albumFallback.CoverArtUrl;
+                        coverUrl = albumFallback.CoverArtUrlLarge ?? albumFallback.CoverArtUrl;
                     }
                 }
                 break;

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -330,6 +330,13 @@ public class DeezerMetadataService : IMusicMetadataService
                           albumForCover.TryGetProperty("cover_medium", out var cover)
                 ? cover.GetString()
                 : null,
+            CoverArtUrlLarge = track.TryGetProperty("album", out var albumForCoverXL) && 
+                          albumForCoverXL.TryGetProperty("cover_xl", out var coverxl)
+                ? coverxl.GetString()
+                :(track.TryGetProperty("album", out var albumForCoverBig) &&
+                   albumForCoverBig.TryGetProperty("cover_big", out var coverBig)
+                    ? coverBig.GetString()
+                : null),
             AlbumArtist = albumArtist,
             IsLocal = false,
             ExternalProvider = "deezer",
@@ -492,6 +499,11 @@ public class DeezerMetadataService : IMusicMetadataService
             CoverArtUrl = album.TryGetProperty("cover_medium", out var cover)
                 ? cover.GetString()
                 : null,
+            CoverArtUrlLarge = album.TryGetProperty("cover_xl", out var coverXl)
+                ? coverXl.GetString()
+                : (album.TryGetProperty("cover_big", out var coverBig)
+                    ? coverBig.GetString()
+                    : null),
             Genre = album.TryGetProperty("genres", out var genres) && 
                     genres.TryGetProperty("data", out var genresData) &&
                     genresData.GetArrayLength() > 0
@@ -511,9 +523,11 @@ public class DeezerMetadataService : IMusicMetadataService
         {
             Id = $"ext-deezer-artist-{externalId}",
             Name = artist.GetProperty("name").GetString() ?? "",
-            ImageUrl = artist.TryGetProperty("picture_medium", out var picture)
+            ImageUrl = artist.TryGetProperty("picture_big", out var pictureBig) 
+                ? pictureBig.GetString() 
+                : (artist.TryGetProperty("picture_medium", out var picture) 
                 ? picture.GetString()
-                : null,
+                : null),
             AlbumCount = artist.TryGetProperty("nb_album", out var nbAlbum) 
                 ? nbAlbum.GetInt32() 
                 : null,
@@ -671,10 +685,10 @@ public class DeezerMetadataService : IMusicMetadataService
             Duration = playlist.TryGetProperty("duration", out var duration) 
                 ? duration.GetInt32() 
                 : 0,
-            CoverUrl = playlist.TryGetProperty("picture_medium", out var picture) 
-                ? picture.GetString() 
-                : (playlist.TryGetProperty("picture_big", out var pictureBig) 
+            CoverUrl = playlist.TryGetProperty("picture_big", out var pictureBig) 
                     ? pictureBig.GetString() 
+                    : (playlist.TryGetProperty("picture_medium", out var picture) 
+                    ? picture.GetString()
                     : null),
             CreatedDate = createdDate
         };

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -331,12 +331,12 @@ public class DeezerMetadataService : IMusicMetadataService
                 ? cover.GetString()
                 : null,
             CoverArtUrlLarge = track.TryGetProperty("album", out var albumForCoverXL) && 
-                          albumForCoverXL.TryGetProperty("cover_xl", out var coverxl)
+                            albumForCoverXL.TryGetProperty("cover_xl", out var coverxl)
                 ? coverxl.GetString()
-                :(track.TryGetProperty("album", out var albumForCoverBig) &&
+                : (track.TryGetProperty("album", out var albumForCoverBig) &&
                    albumForCoverBig.TryGetProperty("cover_big", out var coverBig)
                     ? coverBig.GetString()
-                : null),
+                    : null),
             AlbumArtist = albumArtist,
             IsLocal = false,
             ExternalProvider = "deezer",
@@ -526,8 +526,8 @@ public class DeezerMetadataService : IMusicMetadataService
             ImageUrl = artist.TryGetProperty("picture_big", out var pictureBig) 
                 ? pictureBig.GetString() 
                 : (artist.TryGetProperty("picture_medium", out var picture) 
-                ? picture.GetString()
-                : null),
+                    ? picture.GetString()
+                    : null),
             AlbumCount = artist.TryGetProperty("nb_album", out var nbAlbum) 
                 ? nbAlbum.GetInt32() 
                 : null,


### PR DESCRIPTION
While using Octo-Fiesta, I noticed that, at least while using Deezer and Tidal through SquidWTF, the cover art quality was really low: this request aims to fix that.

- Previously, SubSonicController wasn't using CoverArtUrlLarge at all. Now, it uses that as default, while keeping CoverArtUrl as fallback;
- CoverArtUrlLarge is now available in every parsing related to tracks or albums in DeezerMetadataService;
- Bumped the image of playlists and artists to picturebig while using picturemedium as a fallback in DeezerMetadataService.

I don't know how much these changes will affect performance and bandwidth. Perhaps, using cover_big instead of cover_xl in Deezer might be the smartest choice. But the difference is noticeable and might be bigger while using mobile apps.
<img width="2032" height="1162" alt="before" src="https://github.com/user-attachments/assets/cc0bfb8d-708d-434d-83f3-4bb2f10d039d" />
<img width="2032" height="1162" alt="after" src="https://github.com/user-attachments/assets/c5526610-d42a-4d13-838b-84fe5d8a4337" />

