### PR TITLE
fix: ensure albumId consistency for external playlists

### DIFF
--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -179,7 +179,11 @@ public class SubsonicResponseBuilder
                     genre = "Playlist",
                     isCompilation = false,
                     created = playlist.CreatedDate.HasValue ? playlist.CreatedDate.Value.ToUniversalTime().ToString("o") : System.DateTime.UtcNow.ToString("o"),
-                    song = tracks.Select(s => ConvertSongToJson(s)).ToList()
+                    song = tracks.Select(s => {
+                        var songJson = ConvertSongToJson(s);
+                        songJson["albumId"] = playlist.Id;
+                        return songJson;
+                    }).ToList()
                 }
             });
         }


### PR DESCRIPTION
iOS client Arpeggi was failing to display tracks when an external playlist was served as an album. This was caused by a mismatch between the 'album' object ID and the 'albumId' field within the individual 'song' object.

- Forces song 'albumId' to match the parent playlist ID in JSON responses
- Fixes "empty album" / "0 tracks" view in Arpeggi
- Addresses issues discussed in #31 and #88