### PR TITLE
fix: normalize quotes in duplicate detection

### DIFF
--- a/octo-fiesta.Tests/StringNormalizerTests.cs
+++ b/octo-fiesta.Tests/StringNormalizerTests.cs
@@ -1,0 +1,135 @@
+using octo_fiesta.Services.Common;
+
+namespace octo_fiesta.Tests;
+
+public class StringNormalizerTests
+{
+    [Fact]
+    public void NormalizeForComparison_WithCurlyApostrophe_ReturnsNormalizedString()
+    {
+        // Arrange
+        var input = "The Craving (Jenna‘s Version)"; // Curly apostrophe
+        var expected = "The Craving (Jenna's Version)"; // Straight apostrophe
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithBacktick_ReturnsNormalizedString()
+    {
+        // Arrange
+        var input = "The Craving (Jenna`s Version)";
+        var expected = "The Craving (Jenna's Version)";
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithCurlyDoubleQuotes_ReturnsNormalizedString()
+    {
+        // Arrange
+        var input = "“Hello World”"; // Curly double quotes
+        var expected = "\"Hello World\""; // Straight double quotes
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithLeftSingleQuotationMark_ReturnsNormalizedString()
+    {
+        // Arrange
+        var input = "‘Hello"; // Left single quotation mark
+        var expected = "'Hello"; // Straight apostrophe
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithNoSpecialQuotes_ReturnsUnchanged()
+    {
+        // Arrange
+        var input = "Normal Song Title";
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithEmptyString_ReturnsEmptyString()
+    {
+        // Arrange
+        var input = "";
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void NormalizeForComparison_WithNull_ReturnsEmptyString()
+    {
+        // Arrange
+        string? input = null;
+
+        // Act
+        var result = StringNormalizer.NormalizeForComparison(input);
+
+        // Assert
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void CreateComparisonKey_WithMixedCase_ReturnsCaseInsensitiveKey()
+    {
+        // Arrange
+        var input1 = "It'S A Song";
+        var input2 = "it's a song";
+
+        // Act
+        var key1 = StringNormalizer.CreateComparisonKey(input1);
+        var key2 = StringNormalizer.CreateComparisonKey(input2);
+
+        // Assert
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void CreateComparisonKey_WithDifferentQuotes_ReturnsSameKey()
+    {
+        // Arrange
+        var input1 = "It's"; // Straight apostrophe
+        var input2 = "It’s"; // Curly apostrophe (U+2019)
+        var input3 = "It`s"; // Backtick
+
+        // Act
+        var key1 = StringNormalizer.CreateComparisonKey(input1);
+        var key2 = StringNormalizer.CreateComparisonKey(input2);
+        var key3 = StringNormalizer.CreateComparisonKey(input3);
+
+        // Assert
+        Assert.Equal(key1, key2);
+        Assert.Equal(key1, key3);
+    }
+}
+

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -305,19 +305,21 @@ public class SubsonicController : ControllerBase
             }
         }
 
-        var localAlbumNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var localAlbumNames = new HashSet<string>();
         foreach (var album in localAlbums)
         {
             if (album is Dictionary<string, object> dict && dict.TryGetValue("name", out var nameObj))
             {
-                localAlbumNames.Add(nameObj?.ToString() ?? "");
+                var normalizedName = StringNormalizer.CreateComparisonKey(nameObj?.ToString() ?? "");
+                localAlbumNames.Add(normalizedName);
             }
         }
 
         var mergedAlbums = localAlbums.ToList();
         foreach (var externalAlbum in externalAlbums)
         {
-            if (!localAlbumNames.Contains(externalAlbum.Title))
+            var normalizedExternalName = StringNormalizer.CreateComparisonKey(externalAlbum.Title);
+            if (!localAlbumNames.Contains(normalizedExternalName))
             {
                 mergedAlbums.Add(_responseBuilder.ConvertAlbumToJson(externalAlbum));
             }
@@ -482,19 +484,21 @@ public class SubsonicController : ControllerBase
 
         if (externalAlbum != null && externalAlbum.Songs.Count > 0)
         {
-            var localSongTitles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var localSongTitles = new HashSet<string>();
             foreach (var song in localSongs)
             {
                 if (song is Dictionary<string, object> dict && dict.TryGetValue("title", out var titleObj))
                 {
-                    localSongTitles.Add(titleObj?.ToString() ?? "");
+                    var normalizedTitle = StringNormalizer.CreateComparisonKey(titleObj?.ToString() ?? "");
+                    localSongTitles.Add(normalizedTitle);
                 }
             }
 
             var mergedSongs = localSongs.ToList();
             foreach (var externalSong in externalAlbum.Songs)
             {
-                if (!localSongTitles.Contains(externalSong.Title))
+                var normalizedExternalTitle = StringNormalizer.CreateComparisonKey(externalSong.Title);
+                if (!localSongTitles.Contains(normalizedExternalTitle))
                 {
                     mergedSongs.Add(_responseBuilder.ConvertSongToJson(externalSong));
                 }

--- a/octo-fiesta/Services/Common/StringNormalizer.cs
+++ b/octo-fiesta/Services/Common/StringNormalizer.cs
@@ -1,0 +1,74 @@
+using System.Text;
+
+namespace octo_fiesta.Services.Common;
+
+/// <summary>
+/// Helper class for normalizing strings for comparison purposes.
+/// Handles different quote characters (straight vs curly quotes) and other variants.
+/// </summary>
+public static class StringNormalizer
+{
+    // Mapping of various quote and apostrophe characters to their canonical forms
+    private static readonly Dictionary<char, char> QuoteNormalizations = new()
+    {
+        // Curly quotes to straight quotes
+        { '‘', '\'' },
+        { '’', '\'' },
+        { '“', '"' },
+        { '”', '"' },
+        { '′', '\'' },
+        { '″', '"' },
+        
+        // Backticks to straight quotes
+        { '`', '\'' }
+    };
+
+    /// <summary>
+    /// Normalizes a string for comparison by standardizing quote characters.
+    /// Converts various forms of apostrophes and quotes to their canonical straight forms.
+    /// This allows matching titles like "Jenna's" with "Jenna`s".
+    /// </summary>
+    /// <param name="input">String to normalize.</param>
+    /// <returns>Normalized string comparison.</returns>
+    public static string NormalizeForComparison(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return "";
+        }
+
+        var sb = new StringBuilder(input.Length);
+
+        foreach (var c in input)
+        {
+            if (QuoteNormalizations.TryGetValue(c, out var normalized))
+            {
+                sb.Append(normalized);
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Creates a normalized comparison key for a string.
+    /// Useful for HashSet lookups with normalized values.
+    /// </summary>
+    /// <param name="input">String to create a key for.</param>
+    /// <returns>Normalized string suitable for case-insensitive comparison.</returns>
+    public static string CreateComparisonKey(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return "";
+        }
+
+        return NormalizeForComparison(input).ToLowerInvariant();
+    }
+}
+
+


### PR DESCRIPTION
Prevent duplicates when song/album titles use different quote variants.

- Add StringNormalizer utility for quote normalization
- Update GetAlbum() and GetArtist() duplicate checks
- Add fitting unit tests

Fixes issue where "Jenna's Version" and "Jenna`s Version" were treated as different songs.

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/b433d8c8-5630-464f-969b-6533b5c69491" alt="before" width="300"/> | <img src="https://github.com/user-attachments/assets/b1039235-286f-481f-b04c-352f8c8ba80e" alt="after" width="300"/> |
