### PR TITLE
feat: add per-user download subfolders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ SUBSONIC_URL=http://localhost:4533
 # Path where downloaded songs will be stored on the host (only applies if STORAGE_MODE=Permanent)
 DOWNLOAD_PATH=./downloads
 
+# Per-user download subfolders (optional, default: false)
+# When true and STORAGE_MODE=Permanent, downloads are saved to:
+# {DOWNLOAD_PATH}/{subsonic_username}/Artist/Album/Track
+LIBRARY_USER_SUBFOLDERS=false
+
 # Music service to use: Deezer, Qobuz, or SquidWTF (default: SquidWTF)
 MUSIC_SERVICE=SquidWTF
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       # Download path inside container
       - Library__DownloadPath=/app/downloads
+      # Per-user download subfolders (only applies to Permanent storage mode)
+      - Library__UserSubfolders=${LIBRARY_USER_SUBFOLDERS:-false}
       
       # ===== SUBSONIC SETTINGS =====
       # Navidrome/Subsonic server URL

--- a/octo-fiesta.Tests/DeezerDownloadServiceTests.cs
+++ b/octo-fiesta.Tests/DeezerDownloadServiceTests.cs
@@ -7,6 +7,7 @@ using octo_fiesta.Models.Settings;
 using octo_fiesta.Models.Download;
 using octo_fiesta.Models.Search;
 using octo_fiesta.Models.Subsonic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -75,6 +76,11 @@ public class DeezerDownloadServiceTests : IDisposable
         { 
             DownloadMode = downloadMode 
         });
+        var librarySettings = Options.Create(new LibrarySettings
+        {
+            DownloadPath = _testDownloadPath,
+            UserSubfolders = false
+        });
         
         var deezerSettings = Options.Create(new DeezerSettings
         {
@@ -87,13 +93,17 @@ public class DeezerDownloadServiceTests : IDisposable
         serviceProviderMock.Setup(sp => sp.GetService(typeof(octo_fiesta.Services.Subsonic.PlaylistSyncService)))
             .Returns(null);
 
+        var httpContextAccessor = new HttpContextAccessor();
+
         return new DeezerDownloadService(
             _httpClientFactoryMock.Object,
             config,
             _localLibraryServiceMock.Object,
             _metadataServiceMock.Object,
+            librarySettings,
             subsonicSettings,
             deezerSettings,
+            httpContextAccessor,
             serviceProviderMock.Object,
             _loggerMock.Object);
     }
@@ -236,253 +246,4 @@ public class DeezerDownloadServiceTests : IDisposable
         // Assert - Just verify it doesn't throw, actual download is async
         Assert.True(true);
     }
-}
-
-/// <summary>
-/// Unit tests for the PathHelper class that handles file organization logic.
-/// </summary>
-public class PathHelperTests : IDisposable
-{
-    private readonly string _testPath;
-
-    public PathHelperTests()
-    {
-        _testPath = Path.Combine(Path.GetTempPath(), "octo-fiesta-pathhelper-tests-" + Guid.NewGuid());
-        Directory.CreateDirectory(_testPath);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_testPath))
-        {
-            Directory.Delete(_testPath, true);
-        }
-    }
-
-    #region SanitizeFileName Tests
-
-    [Fact]
-    public void SanitizeFileName_WithValidName_ReturnsUnchanged()
-    {
-        // Arrange & Act
-        var result = PathHelper.SanitizeFileName("My Song Title");
-
-        // Assert
-        Assert.Equal("My Song Title", result);
-    }
-
-    [Fact]
-    public void SanitizeFileName_WithInvalidChars_ReplacesWithUnderscore()
-    {
-        // Arrange - Use forward slash which is invalid on all platforms
-        var result = PathHelper.SanitizeFileName("Song/With/Invalid");
-
-        // Assert - Check that forward slashes were replaced with underscores
-        Assert.Equal("Song_With_Invalid", result);
-    }
-
-    [Fact]
-    public void SanitizeFileName_WithNullOrEmpty_ReturnsUnknown()
-    {
-        // Arrange & Act
-        var resultNull = PathHelper.SanitizeFileName(null!);
-        var resultEmpty = PathHelper.SanitizeFileName("");
-        var resultWhitespace = PathHelper.SanitizeFileName("   ");
-
-        // Assert
-        Assert.Equal("Unknown", resultNull);
-        Assert.Equal("Unknown", resultEmpty);
-        Assert.Equal("Unknown", resultWhitespace);
-    }
-
-    [Fact]
-    public void SanitizeFileName_WithLongName_TruncatesTo100Chars()
-    {
-        // Arrange
-        var longName = new string('A', 150);
-
-        // Act
-        var result = PathHelper.SanitizeFileName(longName);
-
-        // Assert
-        Assert.Equal(100, result.Length);
-    }
-
-    #endregion
-
-    #region SanitizeFolderName Tests
-
-    [Fact]
-    public void SanitizeFolderName_WithValidName_ReturnsUnchanged()
-    {
-        // Arrange & Act
-        var result = PathHelper.SanitizeFolderName("Artist Name");
-
-        // Assert
-        Assert.Equal("Artist Name", result);
-    }
-
-    [Fact]
-    public void SanitizeFolderName_WithNullOrEmpty_ReturnsUnknown()
-    {
-        // Arrange & Act
-        var resultNull = PathHelper.SanitizeFolderName(null!);
-        var resultEmpty = PathHelper.SanitizeFolderName("");
-        var resultWhitespace = PathHelper.SanitizeFolderName("   ");
-
-        // Assert
-        Assert.Equal("Unknown", resultNull);
-        Assert.Equal("Unknown", resultEmpty);
-        Assert.Equal("Unknown", resultWhitespace);
-    }
-
-    [Fact]
-    public void SanitizeFolderName_WithTrailingDots_RemovesDots()
-    {
-        // Arrange & Act
-        var result = PathHelper.SanitizeFolderName("Artist Name...");
-
-        // Assert
-        Assert.Equal("Artist Name", result);
-    }
-
-    [Fact]
-    public void SanitizeFolderName_WithInvalidChars_ReplacesWithUnderscore()
-    {
-        // Arrange - Use forward slash which is invalid on all platforms
-        var result = PathHelper.SanitizeFolderName("Artist/With/Invalid");
-
-        // Assert - Check that forward slashes were replaced with underscores
-        Assert.Equal("Artist_With_Invalid", result);
-    }
-
-    #endregion
-
-    #region BuildTrackPath Tests
-
-    [Fact]
-    public void BuildTrackPath_WithAllParameters_CreatesCorrectStructure()
-    {
-        // Arrange
-        var downloadPath = "/downloads";
-        var artist = "Test Artist";
-        var album = "Test Album";
-        var title = "Test Song";
-        var trackNumber = 5;
-        var extension = ".mp3";
-
-        // Act
-        var result = PathHelper.BuildTrackPath(downloadPath, artist, album, title, trackNumber, extension);
-
-        // Assert
-        Assert.Contains("Test Artist", result);
-        Assert.Contains("Test Album", result);
-        Assert.Contains("05 - Test Song.mp3", result);
-    }
-
-    [Fact]
-    public void BuildTrackPath_WithoutTrackNumber_OmitsTrackPrefix()
-    {
-        // Arrange
-        var downloadPath = "/downloads";
-        var artist = "Test Artist";
-        var album = "Test Album";
-        var title = "Test Song";
-        var extension = ".mp3";
-
-        // Act
-        var result = PathHelper.BuildTrackPath(downloadPath, artist, album, title, null, extension);
-
-        // Assert
-        Assert.Contains("Test Song.mp3", result);
-        Assert.DoesNotContain(" - Test Song", result.Split(Path.DirectorySeparatorChar).Last());
-    }
-
-    [Fact]
-    public void BuildTrackPath_WithSingleDigitTrack_PadsWithZero()
-    {
-        // Arrange & Act
-        var result = PathHelper.BuildTrackPath("/downloads", "Artist", "Album", "Song", 3, ".mp3");
-
-        // Assert
-        Assert.Contains("03 - Song.mp3", result);
-    }
-
-    [Fact]
-    public void BuildTrackPath_WithFlacExtension_UsesFlacExtension()
-    {
-        // Arrange & Act
-        var result = PathHelper.BuildTrackPath("/downloads", "Artist", "Album", "Song", 1, ".flac");
-
-        // Assert
-        Assert.EndsWith(".flac", result);
-    }
-
-    [Fact]
-    public void BuildTrackPath_CreatesArtistAlbumHierarchy()
-    {
-        // Arrange & Act
-        var result = PathHelper.BuildTrackPath("/downloads", "My Artist", "My Album", "My Song", 1, ".mp3");
-
-        // Assert
-        // Verify the structure is: downloadPath/Artist/Album/track.mp3
-        var parts = result.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        Assert.Contains("My Artist", parts);
-        Assert.Contains("My Album", parts);
-        
-        // Artist should come before Album in the path
-        var artistIndex = Array.IndexOf(parts, "My Artist");
-        var albumIndex = Array.IndexOf(parts, "My Album");
-        Assert.True(artistIndex < albumIndex, "Artist folder should be parent of Album folder");
-    }
-
-    #endregion
-
-    #region ResolveUniquePath Tests
-
-    [Fact]
-    public void ResolveUniquePath_WhenFileDoesNotExist_ReturnsSamePath()
-    {
-        // Arrange
-        var path = Path.Combine(_testPath, "nonexistent.mp3");
-
-        // Act
-        var result = PathHelper.ResolveUniquePath(path);
-
-        // Assert
-        Assert.Equal(path, result);
-    }
-
-    [Fact]
-    public void ResolveUniquePath_WhenFileExists_ReturnsPathWithCounter()
-    {
-        // Arrange
-        var basePath = Path.Combine(_testPath, "existing.mp3");
-        File.WriteAllText(basePath, "content");
-
-        // Act
-        var result = PathHelper.ResolveUniquePath(basePath);
-
-        // Assert
-        Assert.NotEqual(basePath, result);
-        Assert.Contains("existing (1).mp3", result);
-    }
-
-    [Fact]
-    public void ResolveUniquePath_WhenMultipleFilesExist_IncrementsCounter()
-    {
-        // Arrange
-        var basePath = Path.Combine(_testPath, "song.mp3");
-        var path1 = Path.Combine(_testPath, "song (1).mp3");
-        File.WriteAllText(basePath, "content");
-        File.WriteAllText(path1, "content");
-
-        // Act
-        var result = PathHelper.ResolveUniquePath(basePath);
-
-        // Assert
-        Assert.Contains("song (2).mp3", result);
-    }
-
-    #endregion
 }

--- a/octo-fiesta.Tests/PathHelperTests.cs
+++ b/octo-fiesta.Tests/PathHelperTests.cs
@@ -1,0 +1,318 @@
+using octo_fiesta.Services.Common;
+
+namespace octo_fiesta.Tests;
+
+/// <summary>
+/// Unit tests for the PathHelper class that handles file organization logic.
+/// </summary>
+public class PathHelperTests : IDisposable
+{
+    private readonly string _testPath;
+
+    public PathHelperTests()
+    {
+        _testPath = Path.Combine(Path.GetTempPath(), "octo-fiesta-pathhelper-tests-" + Guid.NewGuid());
+        Directory.CreateDirectory(_testPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testPath))
+        {
+            Directory.Delete(_testPath, true);
+        }
+    }
+
+    #region SanitizeFileName Tests
+
+    [Fact]
+    public void SanitizeFileName_WithValidName_ReturnsUnchanged()
+    {
+        // Arrange & Act
+        var result = PathHelper.SanitizeFileName("My Song Title");
+
+        // Assert
+        Assert.Equal("My Song Title", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithInvalidChars_ReplacesWithUnderscore()
+    {
+        // Arrange - Use forward slash which is invalid on all platforms
+        var result = PathHelper.SanitizeFileName("Song/With/Invalid");
+
+        // Assert - Check that forward slashes were replaced with underscores
+        Assert.Equal("Song_With_Invalid", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithNullOrEmpty_ReturnsUnknown()
+    {
+        // Arrange & Act
+        var resultNull = PathHelper.SanitizeFileName(null!);
+        var resultEmpty = PathHelper.SanitizeFileName("");
+        var resultWhitespace = PathHelper.SanitizeFileName("   ");
+
+        // Assert
+        Assert.Equal("Unknown", resultNull);
+        Assert.Equal("Unknown", resultEmpty);
+        Assert.Equal("Unknown", resultWhitespace);
+    }
+
+    [Fact]
+    public void SanitizeFileName_WithLongName_TruncatesTo100Chars()
+    {
+        // Arrange
+        var longName = new string('A', 150);
+
+        // Act
+        var result = PathHelper.SanitizeFileName(longName);
+
+        // Assert
+        Assert.Equal(100, result.Length);
+    }
+
+    #endregion
+
+    #region SanitizeFolderName Tests
+
+    [Fact]
+    public void SanitizeFolderName_WithValidName_ReturnsUnchanged()
+    {
+        // Arrange & Act
+        var result = PathHelper.SanitizeFolderName("Artist Name");
+
+        // Assert
+        Assert.Equal("Artist Name", result);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithNullOrEmpty_ReturnsUnknown()
+    {
+        // Arrange & Act
+        var resultNull = PathHelper.SanitizeFolderName(null!);
+        var resultEmpty = PathHelper.SanitizeFolderName("");
+        var resultWhitespace = PathHelper.SanitizeFolderName("   ");
+
+        // Assert
+        Assert.Equal("Unknown", resultNull);
+        Assert.Equal("Unknown", resultEmpty);
+        Assert.Equal("Unknown", resultWhitespace);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithTrailingDots_RemovesDots()
+    {
+        // Arrange & Act
+        var result = PathHelper.SanitizeFolderName("Artist Name...");
+
+        // Assert
+        Assert.Equal("Artist Name", result);
+    }
+
+    [Fact]
+    public void SanitizeFolderName_WithInvalidChars_ReplacesWithUnderscore()
+    {
+        // Arrange - Use forward slash which is invalid on all platforms
+        var result = PathHelper.SanitizeFolderName("Artist/With/Invalid");
+
+        // Assert - Check that forward slashes were replaced with underscores
+        Assert.Equal("Artist_With_Invalid", result);
+    }
+
+    #endregion
+
+    #region BuildTrackPath Tests
+
+    [Fact]
+    public void BuildTrackPath_WithAllParameters_CreatesCorrectStructure()
+    {
+        // Arrange
+        var downloadPath = "/downloads";
+        var artist = "Test Artist";
+        var album = "Test Album";
+        var title = "Test Song";
+        var trackNumber = 5;
+        var extension = ".mp3";
+
+        // Act
+        var result = PathHelper.BuildTrackPath(downloadPath, artist, album, title, trackNumber, extension);
+
+        // Assert
+        Assert.Contains("Test Artist", result);
+        Assert.Contains("Test Album", result);
+        Assert.Contains("05 - Test Song.mp3", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithoutTrackNumber_OmitsTrackPrefix()
+    {
+        // Arrange
+        var downloadPath = "/downloads";
+        var artist = "Test Artist";
+        var album = "Test Album";
+        var title = "Test Song";
+        var extension = ".mp3";
+
+        // Act
+        var result = PathHelper.BuildTrackPath(downloadPath, artist, album, title, null, extension);
+
+        // Assert
+        Assert.Contains("Test Song.mp3", result);
+        Assert.DoesNotContain(" - Test Song", result.Split(Path.DirectorySeparatorChar).Last());
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithSingleDigitTrack_PadsWithZero()
+    {
+        // Arrange & Act
+        var result = PathHelper.BuildTrackPath("/downloads", "Artist", "Album", "Song", 3, ".mp3");
+
+        // Assert
+        Assert.Contains("03 - Song.mp3", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_WithFlacExtension_UsesFlacExtension()
+    {
+        // Arrange & Act
+        var result = PathHelper.BuildTrackPath("/downloads", "Artist", "Album", "Song", 1, ".flac");
+
+        // Assert
+        Assert.EndsWith(".flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_CreatesArtistAlbumHierarchy()
+    {
+        // Arrange & Act
+        var result = PathHelper.BuildTrackPath("/downloads", "My Artist", "My Album", "My Song", 1, ".mp3");
+
+        // Assert
+        // Verify the structure is: downloadPath/Artist/Album/track.mp3
+        var parts = result.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        Assert.Contains("My Artist", parts);
+        Assert.Contains("My Album", parts);
+
+        // Artist should come before Album in the path
+        var artistIndex = Array.IndexOf(parts, "My Artist");
+        var albumIndex = Array.IndexOf(parts, "My Album");
+        Assert.True(artistIndex < albumIndex, "Artist folder should be parent of Album folder");
+    }
+
+    [Fact]
+    public void BuildTrackPath_UserSubfoldersDisabled_IgnoresUsername()
+    {
+        var result = PathHelper.BuildTrackPath(
+            "/downloads",
+            "Radiohead",
+            "Kid A",
+            "Everything in Its Right Place",
+            1,
+            ".flac",
+            userSubfolders: false,
+            username: "alice");
+
+        Assert.Contains(Path.Combine("/downloads", "Radiohead", "Kid A"), result);
+        Assert.DoesNotContain(Path.Combine("/downloads", "alice"), result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_UserSubfoldersEnabled_PrependsUsername()
+    {
+        var result = PathHelper.BuildTrackPath(
+            "/downloads",
+            "Radiohead",
+            "Kid A",
+            "Everything in Its Right Place",
+            1,
+            ".flac",
+            userSubfolders: true,
+            username: "alice");
+
+        Assert.Contains(Path.Combine("/downloads", "alice", "Radiohead", "Kid A"), result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_UserSubfoldersEnabled_NullUsername_FallsBackToRoot()
+    {
+        var result = PathHelper.BuildTrackPath(
+            "/downloads",
+            "Radiohead",
+            "Kid A",
+            "Everything in Its Right Place",
+            1,
+            ".flac",
+            userSubfolders: true,
+            username: null);
+
+        Assert.Contains(Path.Combine("/downloads", "Radiohead", "Kid A"), result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_UserSubfoldersEnabled_SanitizesUsername()
+    {
+        var result = PathHelper.BuildTrackPath(
+            "/downloads",
+            "Artist",
+            "Album",
+            "Track",
+            1,
+            ".flac",
+            userSubfolders: true,
+            username: "../evil");
+
+        Assert.StartsWith("/downloads/", result);
+        Assert.DoesNotContain("..", result);
+    }
+
+    #endregion
+
+    #region ResolveUniquePath Tests
+
+    [Fact]
+    public void ResolveUniquePath_WhenFileDoesNotExist_ReturnsSamePath()
+    {
+        // Arrange
+        var path = Path.Combine(_testPath, "nonexistent.mp3");
+
+        // Act
+        var result = PathHelper.ResolveUniquePath(path);
+
+        // Assert
+        Assert.Equal(path, result);
+    }
+
+    [Fact]
+    public void ResolveUniquePath_WhenFileExists_ReturnsPathWithCounter()
+    {
+        // Arrange
+        var basePath = Path.Combine(_testPath, "existing.mp3");
+        File.WriteAllText(basePath, "content");
+
+        // Act
+        var result = PathHelper.ResolveUniquePath(basePath);
+
+        // Assert
+        Assert.NotEqual(basePath, result);
+        Assert.Contains("existing (1).mp3", result);
+    }
+
+    [Fact]
+    public void ResolveUniquePath_WhenMultipleFilesExist_IncrementsCounter()
+    {
+        // Arrange
+        var basePath = Path.Combine(_testPath, "song.mp3");
+        var path1 = Path.Combine(_testPath, "song (1).mp3");
+        File.WriteAllText(basePath, "content");
+        File.WriteAllText(path1, "content");
+
+        // Act
+        var result = PathHelper.ResolveUniquePath(basePath);
+
+        // Assert
+        Assert.Contains("song (2).mp3", result);
+    }
+
+    #endregion
+}

--- a/octo-fiesta.Tests/QobuzDownloadServiceTests.cs
+++ b/octo-fiesta.Tests/QobuzDownloadServiceTests.cs
@@ -5,6 +5,7 @@ using octo_fiesta.Models.Domain;
 using octo_fiesta.Models.Settings;
 using octo_fiesta.Models.Download;
 using octo_fiesta.Models.Subsonic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -78,6 +79,11 @@ public class QobuzDownloadServiceTests : IDisposable
         { 
             DownloadMode = downloadMode 
         });
+        var librarySettings = Options.Create(new LibrarySettings
+        {
+            DownloadPath = _testDownloadPath,
+            UserSubfolders = false
+        });
         
         var qobuzSettings = Options.Create(new QobuzSettings
         {
@@ -90,14 +96,18 @@ public class QobuzDownloadServiceTests : IDisposable
         serviceProviderMock.Setup(sp => sp.GetService(typeof(octo_fiesta.Services.Subsonic.PlaylistSyncService)))
             .Returns(null);
 
+        var httpContextAccessor = new HttpContextAccessor();
+
         return new QobuzDownloadService(
             _httpClientFactoryMock.Object,
             config,
             _localLibraryServiceMock.Object,
             _metadataServiceMock.Object,
             _bundleService,
+            librarySettings,
             subsonicSettings,
             qobuzSettings,
+            httpContextAccessor,
             serviceProviderMock.Object,
             _loggerMock.Object);
     }

--- a/octo-fiesta/Models/Settings/LibrarySettings.cs
+++ b/octo-fiesta/Models/Settings/LibrarySettings.cs
@@ -1,0 +1,18 @@
+namespace octo_fiesta.Models.Settings;
+
+/// <summary>
+/// Library storage settings.
+/// </summary>
+public class LibrarySettings
+{
+    /// <summary>
+    /// Base path where downloaded tracks are stored.
+    /// </summary>
+    public string DownloadPath { get; set; } = "./downloads";
+
+    /// <summary>
+    /// When true (and StorageMode=Permanent), downloads are saved to
+    /// {DownloadPath}/{username}/Artist/Album/Track.
+    /// </summary>
+    public bool UserSubfolders { get; set; } = false;
+}

--- a/octo-fiesta/Program.cs
+++ b/octo-fiesta/Program.cs
@@ -26,6 +26,8 @@ builder.Services.AddProblemDetails();
 // Configuration
 builder.Services.Configure<SubsonicSettings>(
     builder.Configuration.GetSection("Subsonic"));
+builder.Services.Configure<LibrarySettings>(
+    builder.Configuration.GetSection("Library"));
 builder.Services.Configure<DeezerSettings>(
     builder.Configuration.GetSection("Deezer"));
 builder.Services.Configure<QobuzSettings>(

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -5,6 +5,8 @@ using octo_fiesta.Models.Search;
 using octo_fiesta.Models.Subsonic;
 using octo_fiesta.Services.Local;
 using octo_fiesta.Services.Subsonic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using TagLib;
 using IOFile = System.IO.File;
 using System.Collections.Concurrent;
@@ -22,8 +24,10 @@ public abstract class BaseDownloadService : IDownloadService
     protected readonly ILocalLibraryService LocalLibraryService;
     protected readonly IMusicMetadataService MetadataService;
     protected readonly SubsonicSettings SubsonicSettings;
+    protected readonly LibrarySettings LibrarySettings;
     protected readonly ILogger Logger;
     private readonly IServiceProvider _serviceProvider;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     protected readonly string DownloadPath;
     protected readonly string CachePath;
@@ -68,7 +72,9 @@ public abstract class BaseDownloadService : IDownloadService
         IConfiguration configuration,
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
+        IOptions<LibrarySettings> librarySettings,
         SubsonicSettings subsonicSettings,
+        IHttpContextAccessor httpContextAccessor,
         IServiceProvider serviceProvider,
         ILogger logger)
     {
@@ -76,7 +82,9 @@ public abstract class BaseDownloadService : IDownloadService
         Configuration = configuration;
         LocalLibraryService = localLibraryService;
         MetadataService = metadataService;
+        LibrarySettings = librarySettings.Value;
         SubsonicSettings = subsonicSettings;
+        _httpContextAccessor = httpContextAccessor;
         _serviceProvider = serviceProvider;
         Logger = logger;
 
@@ -92,6 +100,29 @@ public abstract class BaseDownloadService : IDownloadService
         {
             Directory.CreateDirectory(CachePath);
         }
+    }
+
+    /// <summary>
+    /// Returns true when per-user subfolders should be applied to paths.
+    /// This only applies to permanent storage mode.
+    /// </summary>
+    protected bool ShouldUseUserSubfolders()
+        => LibrarySettings.UserSubfolders && SubsonicSettings.StorageMode != StorageMode.Cache;
+
+    /// <summary>
+    /// Gets the Subsonic username from the current HTTP request.
+    /// Returns null when there is no active HTTP context or no username parameter.
+    /// </summary>
+    protected string? GetCurrentRequestUsername()
+    {
+        var request = _httpContextAccessor.HttpContext?.Request;
+        if (request == null)
+        {
+            return null;
+        }
+
+        var username = request.Query["u"].ToString();
+        return string.IsNullOrWhiteSpace(username) ? null : username;
     }
 
     #region IDownloadService Implementation

--- a/octo-fiesta/Services/Common/PathHelper.cs
+++ b/octo-fiesta/Services/Common/PathHelper.cs
@@ -43,14 +43,32 @@ public static class PathHelper
     /// <param name="title">Track title (will be sanitized).</param>
     /// <param name="trackNumber">Optional track number for prefix.</param>
     /// <param name="extension">File extension (e.g., ".flac", ".mp3").</param>
+    /// <param name="userSubfolders">
+    /// When true and username is provided, prepends a user folder under downloadPath.
+    /// </param>
+    /// <param name="username">Optional username used when userSubfolders is enabled.</param>
     /// <returns>Full path for the track file.</returns>
-    public static string BuildTrackPath(string downloadPath, string artist, string album, string title, int? trackNumber, string extension)
+    public static string BuildTrackPath(
+        string downloadPath,
+        string artist,
+        string album,
+        string title,
+        int? trackNumber,
+        string extension,
+        bool userSubfolders = false,
+        string? username = null)
     {
+        var effectiveBasePath = downloadPath;
+        if (userSubfolders && !string.IsNullOrWhiteSpace(username))
+        {
+            effectiveBasePath = Path.Combine(downloadPath, SanitizeFolderName(username));
+        }
+
         var safeArtist = SanitizeFolderName(artist);
         var safeAlbum = SanitizeFolderName(album);
         var safeTitle = SanitizeFileName(title);
         
-        var artistFolder = Path.Combine(downloadPath, safeArtist);
+        var artistFolder = Path.Combine(effectiveBasePath, safeArtist);
         var albumFolder = Path.Combine(artistFolder, safeAlbum);
         
         var trackPrefix = trackNumber.HasValue ? $"{trackNumber:D2} - " : "";
@@ -101,9 +119,15 @@ public static class PathHelper
         var sanitized = new string(folderName
             .Select(c => invalidChars.Contains(c) ? '_' : c)
             .ToArray());
+
+        // Avoid relative path segments such as "..".
+        while (sanitized.Contains("..", StringComparison.Ordinal))
+        {
+            sanitized = sanitized.Replace("..", "", StringComparison.Ordinal);
+        }
         
         // Remove leading/trailing dots and spaces (Windows folder restrictions)
-        sanitized = sanitized.Trim().TrimEnd('.');
+        sanitized = sanitized.Trim().Trim('.');
         
         if (sanitized.Length > 100)
         {

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -12,6 +12,7 @@ using octo_fiesta.Models.Subsonic;
 using octo_fiesta.Services.Local;
 using octo_fiesta.Services.Common;
 using octo_fiesta.Services.Subsonic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using IOFile = System.IO.File;
 
@@ -49,11 +50,13 @@ public class DeezerDownloadService : BaseDownloadService
         IConfiguration configuration,
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
+        IOptions<LibrarySettings> librarySettings,
         IOptions<SubsonicSettings> subsonicSettings,
         IOptions<DeezerSettings> deezerSettings,
+        IHttpContextAccessor httpContextAccessor,
         IServiceProvider serviceProvider,
         ILogger<DeezerDownloadService> logger)
-        : base(httpClientFactory, configuration, localLibraryService, metadataService, subsonicSettings.Value, serviceProvider, logger)
+        : base(httpClientFactory, configuration, localLibraryService, metadataService, librarySettings, subsonicSettings.Value, httpContextAccessor, serviceProvider, logger)
     {
         _httpClient = httpClientFactory.CreateClient();
         
@@ -123,7 +126,15 @@ public class DeezerDownloadService : BaseDownloadService
         // Build organized folder structure: Artist/Album/Track using AlbumArtist (fallback to Artist for singles)
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(
+            basePath,
+            artistForPath,
+            song.Album,
+            song.Title,
+            song.Track,
+            extension,
+            ShouldUseUserSubfolders(),
+            GetCurrentRequestUsername());
         
         // Create directories if they don't exist
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -9,6 +9,7 @@ using octo_fiesta.Models.Subsonic;
 using octo_fiesta.Services.Local;
 using octo_fiesta.Services.Common;
 using octo_fiesta.Services.Subsonic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using IOFile = System.IO.File;
 
@@ -42,11 +43,13 @@ public class QobuzDownloadService : BaseDownloadService
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
         QobuzBundleService bundleService,
+        IOptions<LibrarySettings> librarySettings,
         IOptions<SubsonicSettings> subsonicSettings,
         IOptions<QobuzSettings> qobuzSettings,
+        IHttpContextAccessor httpContextAccessor,
         IServiceProvider serviceProvider,
         ILogger<QobuzDownloadService> logger)
-        : base(httpClientFactory, configuration, localLibraryService, metadataService, subsonicSettings.Value, serviceProvider, logger)
+        : base(httpClientFactory, configuration, localLibraryService, metadataService, librarySettings, subsonicSettings.Value, httpContextAccessor, serviceProvider, logger)
     {
         _httpClient = httpClientFactory.CreateClient();
         _bundleService = bundleService;
@@ -123,7 +126,15 @@ public class QobuzDownloadService : BaseDownloadService
         // Build organized folder structure using AlbumArtist (fallback to Artist for singles)
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(
+            basePath,
+            artistForPath,
+            song.Album,
+            song.Title,
+            song.Track,
+            extension,
+            ShouldUseUserSubfolders(),
+            GetCurrentRequestUsername());
         
         var albumFolder = Path.GetDirectoryName(outputPath)!;
         EnsureDirectoryExists(albumFolder);

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -5,6 +5,7 @@ using octo_fiesta.Models.Settings;
 using octo_fiesta.Models.SquidWTF;
 using octo_fiesta.Services.Local;
 using octo_fiesta.Services.Common;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using IOFile = System.IO.File;
 
@@ -43,12 +44,14 @@ public class SquidWTFDownloadService : BaseDownloadService
         IConfiguration configuration,
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
+        IOptions<LibrarySettings> librarySettings,
         IOptions<SubsonicSettings> subsonicSettings,
         IOptions<SquidWTFSettings> squidWTFSettings,
         SquidWTFInstanceManager instanceManager,
+        IHttpContextAccessor httpContextAccessor,
         IServiceProvider serviceProvider,
         ILogger<SquidWTFDownloadService> logger)
-        : base(httpClientFactory, configuration, localLibraryService, metadataService, subsonicSettings.Value, serviceProvider, logger)
+        : base(httpClientFactory, configuration, localLibraryService, metadataService, librarySettings, subsonicSettings.Value, httpContextAccessor, serviceProvider, logger)
     {
         _httpClient = httpClientFactory.CreateClient();
         _squidWTFSettings = squidWTFSettings.Value;
@@ -164,7 +167,15 @@ public class SquidWTFDownloadService : BaseDownloadService
         // Build output path
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(
+            basePath,
+            artistForPath,
+            song.Album,
+            song.Title,
+            song.Track,
+            extension,
+            ShouldUseUserSubfolders(),
+            GetCurrentRequestUsername());
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;
@@ -227,7 +238,15 @@ public class SquidWTFDownloadService : BaseDownloadService
         // Build output path
         var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(
+            basePath,
+            artistForPath,
+            song.Album,
+            song.Title,
+            song.Track,
+            extension,
+            ShouldUseUserSubfolders(),
+            GetCurrentRequestUsername());
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/appsettings.json
+++ b/octo-fiesta/appsettings.json
@@ -16,7 +16,8 @@
     "CacheDurationHours": 1
   },
   "Library": {
-    "DownloadPath": "./downloads"
+    "DownloadPath": "./downloads",
+    "UserSubfolders": false
   },
   "Deezer": {
     "Arl": "",


### PR DESCRIPTION
## Problem

In multi-user setups, all downloads currently go to the same root dir,  so downstream routing per-user is difficult.

## Idea

Use "u=" tag from Subsonic as the subdir for that user.
Example: 
1) u=_myuser_
2) DOWNLOAD_PATH=/opt/octo-fiesta/downloads
3) LIBRARY_USER_SUBFOLDERS=true
4) Downloaded track lands in /opt/octo-fiesta/downloads/_myuser_/...

## Solution

Adds opt-in Library.UserSubfolders with default false. When enabled and storage is Permanent, downloads are saved under DownloadPath/username/Artist/Album/Track. Username is resolved per request via [octo-fiesta/Services/Common/BaseDownloadService.cs](octo-fiesta/Services/Common/BaseDownloadService.cs), without changing [octo-fiesta/Services/IDownloadService.cs](octo-fiesta/Services/IDownloadService.cs).

### Scope highlights
- New typed settings model: [octo-fiesta/Models/Settings/LibrarySettings.cs](octo-fiesta/Models/Settings/LibrarySettings.cs)
- Config binding: [octo-fiesta/Program.cs](octo-fiesta/Program.cs)
- Path behavior update: [octo-fiesta/Services/Common/PathHelper.cs](octo-fiesta/Services/Common/PathHelper.cs)
- Provider wiring updates: [octo-fiesta/Services/Deezer/DeezerDownloadService.cs](octo-fiesta/Services/Deezer/DeezerDownloadService.cs), [octo-fiesta/Services/Qobuz/QobuzDownloadService.cs](octo-fiesta/Services/Qobuz/QobuzDownloadService.cs), [octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs](octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs)
- Config docs/wiring: [.env.example](.env.example), [docker-compose.yml](docker-compose.yml), [octo-fiesta/appsettings.json](octo-fiesta/appsettings.json)
- Test split + new coverage: [octo-fiesta.Tests/PathHelperTests.cs](octo-fiesta.Tests/PathHelperTests.cs)

### Behavior/compatibility
- Default false preserves current behavior
- Applies only in Permanent mode
- Cache behavior remains global
- Username path segment sanitized in [octo-fiesta/Services/Common/PathHelper.cs](octo-fiesta/Services/Common/PathHelper.cs)

### Testing
- Unit tests passing: 261/261
- Includes new path-helper cases for enabled/disabled/null/malicious username
- Default behavior unchanged when UserSubfolders=false
- Permanent mode with username routes to per-user folder
