### PR TITLE
feat: add configurable folder template for downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,13 @@ CACHE_DURATION_HOURS=1
 # Example: If you upgrade from Deezer Free (MP3) to Premium (FLAC), existing MP3 files
 # will be automatically replaced with FLAC versions when accessed
 AUTO_UPGRADE_QUALITY=false
+
+# Folder template for organizing downloaded files (optional)
+# Default: {artist}/{album}/{track} - {title}
+# Available placeholders: {artist}, {album}, {title}, {track}, {disc}, {year}, {genre}, {quality}
+# The last segment is the file name (extension is added automatically), slashes separate folder levels
+# Examples:
+#   {artist}/{album}/{track} - {title}
+#   {artist}/[{year}] {album} ({quality})/{track} - {title}
+#   {artist} - {year} - {album}/{disc}-{track} - {title}
+FOLDER_TEMPLATE={artist}/{album}/{track} - {title}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - Subsonic__DownloadMode=${DOWNLOAD_MODE:-Track}
       # Auto upgrade quality: re-download tracks when higher quality is available (default: false)
       - Subsonic__AutoUpgradeQuality=${AUTO_UPGRADE_QUALITY:-false}
+      # Folder template for organizing downloaded files (default: {artist}/{album}/{track} - {title})
+      # Available placeholders: {artist}, {album}, {title}, {track}, {disc}, {year}, {genre}, {quality}
+      - Subsonic__FolderTemplate=${FOLDER_TEMPLATE:-{artist}/{album}/{track} - {title}}
       
       # ===== DEEZER SETTINGS =====
       # Deezer ARL token (required if using Deezer)

--- a/octo-fiesta.Tests/PathHelperTests.cs
+++ b/octo-fiesta.Tests/PathHelperTests.cs
@@ -1,0 +1,323 @@
+using octo_fiesta.Models.Domain;
+using octo_fiesta.Services.Common;
+using Xunit;
+
+namespace octo_fiesta.Tests;
+
+public class PathHelperTemplateTests
+{
+    private static readonly string Sep = Path.DirectorySeparatorChar.ToString();
+
+    #region Legacy BuildTrackPath (backward compatibility)
+
+    [Fact]
+    public void BuildTrackPath_Legacy_WithTrackNumber_ReturnsExpectedPath()
+    {
+        var result = PathHelper.BuildTrackPath("/downloads", "Radiohead", "Kid A", "Everything in Its Right Place", 1, ".flac");
+
+        Assert.Equal($"/downloads{Sep}Radiohead{Sep}Kid A{Sep}01 - Everything in Its Right Place.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_Legacy_WithoutTrackNumber_OmitsPrefix()
+    {
+        var result = PathHelper.BuildTrackPath("/downloads", "Radiohead", "Kid A", "Everything in Its Right Place", null, ".flac");
+
+        Assert.Equal($"/downloads{Sep}Radiohead{Sep}Kid A{Sep}Everything in Its Right Place.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_Legacy_SanitizesSpecialCharacters()
+    {
+        var result = PathHelper.BuildTrackPath("/downloads", "AC/DC", "Back in Black", "Hells Bells", 1, ".mp3");
+
+        Assert.Equal($"/downloads{Sep}AC_DC{Sep}Back in Black{Sep}01 - Hells Bells.mp3", result);
+    }
+
+    #endregion
+
+    #region Template-based BuildTrackPath
+
+    [Fact]
+    public void BuildTrackPath_DefaultTemplate_MatchesLegacyBehavior()
+    {
+        var song = new Song
+        {
+            Title = "Everything in Its Right Place",
+            Artist = "Radiohead",
+            Album = "Kid A",
+            Track = 1
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac", PathHelper.DefaultTemplate, "FLAC");
+
+        Assert.Equal($"/downloads{Sep}Radiohead{Sep}Kid A{Sep}01 - Everything in Its Right Place.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_DefaultTemplate_UsesAlbumArtistWhenAvailable()
+    {
+        var song = new Song
+        {
+            Title = "My Song",
+            Artist = "Track Artist",
+            AlbumArtist = "Album Artist",
+            Album = "My Album",
+            Track = 1
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac", PathHelper.DefaultTemplate, null);
+
+        Assert.Equal($"/downloads{Sep}Album Artist{Sep}My Album{Sep}01 - My Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_CustomTemplate_WithYearAndQuality()
+    {
+        var song = new Song
+        {
+            Title = "Idioteque",
+            Artist = "Radiohead",
+            Album = "Kid A",
+            Track = 8,
+            Year = 2000
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/[{year}] {album} ({quality})/{track} - {title}", "FLAC");
+
+        Assert.Equal($"/downloads{Sep}Radiohead{Sep}[2000] Kid A (FLAC){Sep}08 - Idioteque.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_CustomTemplate_WithDiscNumber()
+    {
+        var song = new Song
+        {
+            Title = "My Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 3,
+            DiscNumber = 2
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/{album}/{disc}-{track} - {title}", "FLAC");
+
+        Assert.Equal($"/downloads{Sep}Artist{Sep}Album{Sep}2-03 - My Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_CustomTemplate_WithGenre()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1,
+            Genre = "Alternative"
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{genre}/{artist}/{album}/{track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Alternative{Sep}Artist{Sep}Album{Sep}01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_NullYear_ReplacesWithUnknown()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1,
+            Year = null
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/[{year}] {album}/{track} - {title}", "FLAC");
+
+        Assert.Equal($"/downloads{Sep}Artist{Sep}[Unknown] Album{Sep}01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_NullGenre_ReplacesWithUnknown()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1,
+            Genre = null
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{genre}/{artist}/{track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Unknown{Sep}Artist{Sep}01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_NullQuality_ReplacesWithUnknown()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/{album} ({quality})/{track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Artist{Sep}Album (Unknown){Sep}01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_NullDiscNumber_ReplacesWithUnknown()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1,
+            DiscNumber = null
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/{album}/Disc {disc}/{track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Artist{Sep}Album{Sep}Disc Unknown{Sep}01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_NoTrackNumber_CleansUpDashPrefix()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = null
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/{album}/{track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Artist{Sep}Album{Sep}Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_FlatTemplate_NoFolderSegments()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            Album = "Album",
+            Track = 1
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist} - {album} - {track} - {title}", null);
+
+        Assert.Equal($"/downloads{Sep}Artist - Album - 01 - Song.flac", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_SpecialCharactersInMetadata_Sanitized()
+    {
+        var song = new Song
+        {
+            Title = "What's My Age Again?",
+            Artist = "AC/DC",
+            Album = "Who Made Who: Disc 1",
+            Track = 5
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac", PathHelper.DefaultTemplate, null);
+
+        // '/' and '?' and ':' should be replaced with '_'
+        Assert.Contains("AC_DC", result);
+        Assert.Contains("Who Made Who_ Disc 1", result);
+        Assert.Contains("What's My Age Again_", result);
+    }
+
+    [Fact]
+    public void BuildTrackPath_AllPlaceholders_AllResolved()
+    {
+        var song = new Song
+        {
+            Title = "Song",
+            Artist = "Artist",
+            AlbumArtist = "AlbumArtist",
+            Album = "Album",
+            Track = 3,
+            DiscNumber = 2,
+            Year = 2023,
+            Genre = "Rock"
+        };
+
+        var result = PathHelper.BuildTrackPath("/downloads", song, ".flac",
+            "{artist}/[{year}] {album} ({quality})/Disc {disc}/{track} - {title} [{genre}]", "FLAC_24");
+
+        Assert.Equal(
+            $"/downloads{Sep}AlbumArtist{Sep}[2023] Album (FLAC_24){Sep}Disc 2{Sep}03 - Song [Rock].flac",
+            result);
+    }
+
+    #endregion
+
+    #region SanitizeFileName
+
+    [Theory]
+    [InlineData("Normal Name", "Normal Name")]
+    [InlineData("Name/With/Slashes", "Name_With_Slashes")]
+    [InlineData("Name:With:Colons", "Name_With_Colons")]
+    [InlineData("Name*With*Stars", "Name_With_Stars")]
+    [InlineData("", "Unknown")]
+    [InlineData("   ", "Unknown")]
+    public void SanitizeFileName_ReplacesInvalidChars(string input, string expected)
+    {
+        Assert.Equal(expected, PathHelper.SanitizeFileName(input));
+    }
+
+    [Fact]
+    public void SanitizeFileName_TruncatesAt100Characters()
+    {
+        var longName = new string('A', 150);
+        var result = PathHelper.SanitizeFileName(longName);
+        Assert.Equal(100, result.Length);
+    }
+
+    #endregion
+
+    #region SanitizeFolderName
+
+    [Theory]
+    [InlineData("Normal Name", "Normal Name")]
+    [InlineData("Name.", "Name")]
+    [InlineData("...Name...", "...Name")]
+    [InlineData("", "Unknown")]
+    [InlineData("   ", "Unknown")]
+    public void SanitizeFolderName_HandlesEdgeCases(string input, string expected)
+    {
+        Assert.Equal(expected, PathHelper.SanitizeFolderName(input));
+    }
+
+    [Fact]
+    public void SanitizeFolderName_TruncatesAt100Characters()
+    {
+        var longName = new string('A', 150);
+        var result = PathHelper.SanitizeFolderName(longName);
+        Assert.Equal(100, result.Length);
+    }
+
+    #endregion
+}

--- a/octo-fiesta/Models/Settings/SubsonicSettings.cs
+++ b/octo-fiesta/Models/Settings/SubsonicSettings.cs
@@ -142,4 +142,12 @@ public class SubsonicSettings
     /// the track will be re-downloaded in FLAC
     /// </summary>
     public bool AutoUpgradeQuality { get; set; } = false;
+    
+    /// <summary>
+    /// Template for organizing downloaded files into folders (default: {artist}/{album}/{track} - {title})
+    /// Environment variable: FOLDER_TEMPLATE
+    /// Available placeholders: {artist}, {album}, {title}, {track}, {disc}, {year}, {genre}, {quality}
+    /// Slashes (/) separate folder levels; the last segment becomes the file name.
+    /// </summary>
+    public string FolderTemplate { get; set; } = "{artist}/{album}/{track} - {title}";
 }

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -829,35 +829,24 @@ public abstract class BaseDownloadService : IDownloadService
             }
 
             var artistForPath = song.AlbumArtist ?? song.Artist;
-            var safeArtist = PathHelper.SanitizeFolderName(artistForPath);
-            var safeAlbum = PathHelper.SanitizeFolderName(song.Album);
-            var safeTitle = PathHelper.SanitizeFileName(song.Title);
 
-            var albumFolder = Path.Combine(CachePath, safeArtist, safeAlbum);
-            if (!Directory.Exists(albumFolder))
+            // Build the expected file name from the last segment of the template.
+            // We don't know the quality at lookup time, so we search by file name pattern
+            // within the entire cache directory tree to handle any folder template.
+            var template = SubsonicSettings.FolderTemplate;
+            var templateSegments = template.Split('/');
+            var fileNameTemplate = templateSegments[^1];
+
+            var expectedFileName = PathHelper.ReplacePlaceholders(fileNameTemplate, song, artistForPath, null);
+            var safeFileName = PathHelper.SanitizeFileName(expectedFileName);
+
+            // Search from the cache root for any file matching the expected name,
+            // regardless of the folder structure used by the template.
+            var searchPattern = $"{safeFileName}*.*";
+            var matches = Directory.GetFiles(CachePath, searchPattern, SearchOption.AllDirectories);
+            if (matches.Length > 0)
             {
-                return null;
-            }
-
-            var trackPrefix = song.Track.HasValue ? $"{song.Track.Value:D2} - " : string.Empty;
-
-            // Prefer exact expected prefix, but allow duplicates resolved by " (n)" suffix.
-            var primaryPattern = $"{trackPrefix}{safeTitle}*.*";
-            var primaryMatches = Directory.GetFiles(albumFolder, primaryPattern, SearchOption.TopDirectoryOnly);
-            if (primaryMatches.Length > 0)
-            {
-                return primaryMatches[0];
-            }
-
-            // If track numbers differ/missing, try title-only match within the same album folder.
-            if (!string.IsNullOrEmpty(trackPrefix))
-            {
-                var fallbackPattern = $"{safeTitle}*.*";
-                var fallbackMatches = Directory.GetFiles(albumFolder, fallbackPattern, SearchOption.TopDirectoryOnly);
-                if (fallbackMatches.Length > 0)
-                {
-                    return fallbackMatches[0];
-                }
+                return matches[0];
             }
 
             return null;

--- a/octo-fiesta/Services/Common/PathHelper.cs
+++ b/octo-fiesta/Services/Common/PathHelper.cs
@@ -1,3 +1,4 @@
+using octo_fiesta.Models.Domain;
 using IOFile = System.IO.File;
 
 namespace octo_fiesta.Services.Common;
@@ -35,7 +36,13 @@ public static class PathHelper
     }
     
     /// <summary>
+    /// Default folder template matching the legacy Artist/Album/Track structure.
+    /// </summary>
+    public const string DefaultTemplate = "{artist}/{album}/{track} - {title}";
+
+    /// <summary>
     /// Builds the output path for a downloaded track following the Artist/Album/Track structure.
+    /// Legacy overload — delegates to the template-based version with the default template.
     /// </summary>
     /// <param name="downloadPath">Base download directory path.</param>
     /// <param name="artist">Artist name (will be sanitized).</param>
@@ -46,17 +53,94 @@ public static class PathHelper
     /// <returns>Full path for the track file.</returns>
     public static string BuildTrackPath(string downloadPath, string artist, string album, string title, int? trackNumber, string extension)
     {
-        var safeArtist = SanitizeFolderName(artist);
-        var safeAlbum = SanitizeFolderName(album);
-        var safeTitle = SanitizeFileName(title);
-        
-        var artistFolder = Path.Combine(downloadPath, safeArtist);
-        var albumFolder = Path.Combine(artistFolder, safeAlbum);
-        
-        var trackPrefix = trackNumber.HasValue ? $"{trackNumber:D2} - " : "";
-        var fileName = $"{trackPrefix}{safeTitle}{extension}";
-        
-        return Path.Combine(albumFolder, fileName);
+        var song = new Song
+        {
+            Title = title,
+            Artist = artist,
+            Album = album,
+            Track = trackNumber
+        };
+        return BuildTrackPath(downloadPath, song, extension, DefaultTemplate, null);
+    }
+
+    /// <summary>
+    /// Builds the output path for a downloaded track using a configurable folder template.
+    /// The template is split on '/' — segments before the last become folders (sanitized via
+    /// <see cref="SanitizeFolderName"/>), the last segment becomes the file name (sanitized via
+    /// <see cref="SanitizeFileName"/>). The file extension is appended automatically.
+    /// </summary>
+    /// <param name="downloadPath">Base download directory path.</param>
+    /// <param name="song">Song metadata providing all placeholder values.</param>
+    /// <param name="extension">File extension including the dot (e.g., ".flac", ".mp3").</param>
+    /// <param name="template">Folder template with {placeholder} tokens. Uses '/' to separate folder levels.</param>
+    /// <param name="downloadedQuality">Quality string for {quality} placeholder (e.g., "FLAC", "MP3_320").</param>
+    /// <returns>Full path for the track file.</returns>
+    public static string BuildTrackPath(string downloadPath, Song song, string extension, string template, string? downloadedQuality)
+    {
+        var artistForPath = song.AlbumArtist ?? song.Artist;
+
+        var segments = template.Split('/');
+        var result = downloadPath;
+
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = ReplacePlaceholders(segments[i], song, artistForPath, downloadedQuality);
+            var isFileName = i == segments.Length - 1;
+
+            if (isFileName)
+            {
+                var safeFileName = SanitizeFileName(segment);
+                result = Path.Combine(result, $"{safeFileName}{extension}");
+            }
+            else
+            {
+                var safeFolder = SanitizeFolderName(segment);
+                result = Path.Combine(result, safeFolder);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Replaces template placeholders with actual metadata values.
+    /// </summary>
+    internal static string ReplacePlaceholders(string segment, Song song, string artistForPath, string? downloadedQuality)
+    {
+        var result = segment
+            .Replace("{artist}", artistForPath)
+            .Replace("{album}", song.Album)
+            .Replace("{title}", song.Title);
+
+        // {track} — zero-padded track number, empty string if null
+        var trackValue = song.Track.HasValue ? $"{song.Track.Value:D2}" : "";
+        result = result.Replace("{track}", trackValue);
+
+        // {disc} — disc number, "Unknown" if null
+        var discValue = song.DiscNumber.HasValue ? song.DiscNumber.Value.ToString() : "Unknown";
+        result = result.Replace("{disc}", discValue);
+
+        // {year} — year, "Unknown" if null
+        var yearValue = song.Year.HasValue ? song.Year.Value.ToString() : "Unknown";
+        result = result.Replace("{year}", yearValue);
+
+        // {genre} — genre, "Unknown" if null/empty
+        var genreValue = string.IsNullOrWhiteSpace(song.Genre) ? "Unknown" : song.Genre;
+        result = result.Replace("{genre}", genreValue);
+
+        // {quality} — downloaded quality, "Unknown" if null/empty
+        var qualityValue = string.IsNullOrWhiteSpace(downloadedQuality) ? "Unknown" : downloadedQuality;
+        result = result.Replace("{quality}", qualityValue);
+
+        // Clean up artifacts from empty placeholders:
+        // If {track} was empty, we might have leftover " - " at the start of the segment
+        // e.g., template "{track} - {title}" with no track → " - My Song" → "My Song"
+        if (!song.Track.HasValue)
+        {
+            result = result.TrimStart(' ', '-').TrimStart();
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -120,10 +120,9 @@ public class DeezerDownloadService : BaseDownloadService
             _ => downloadInfo.Format
         };
 
-        // Build organized folder structure: Artist/Album/Track using AlbumArtist (fallback to Artist for singles)
-        var artistForPath = song.AlbumArtist ?? song.Artist;
+        // Build organized folder structure using configured template
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories if they don't exist
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -120,10 +120,9 @@ public class QobuzDownloadService : BaseDownloadService
             _ => downloadInfo.MimeType?.Contains("flac") == true ? "FLAC" : "MP3_320"
         };
 
-        // Build organized folder structure using AlbumArtist (fallback to Artist for singles)
-        var artistForPath = song.AlbumArtist ?? song.Artist;
+        // Build organized folder structure using configured template
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         var albumFolder = Path.GetDirectoryName(outputPath)!;
         EnsureDirectoryExists(albumFolder);

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -162,9 +162,8 @@ public class SquidWTFDownloadService : BaseDownloadService
         };
         
         // Build output path
-        var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;
@@ -225,9 +224,8 @@ public class SquidWTFDownloadService : BaseDownloadService
         var downloadedQuality = GetDownloadedQuality(actualQuality, manifest.MimeType);
         
         // Build output path
-        var artistForPath = song.AlbumArtist ?? song.Artist;
         var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, artistForPath, song.Album, song.Title, song.Track, extension);
+        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories
         var albumFolder = Path.GetDirectoryName(outputPath)!;


### PR DESCRIPTION
Adds a configurable folder template (`FOLDER_TEMPLATE`) that controls how downloaded files are organized on disk.

- New `FolderTemplate` setting with 8 placeholders: `{artist}`, `{album}`, `{title}`, `{track}`, `{disc}`, `{year}`, `{genre}`, `{quality}`
- Default template `{artist}/{album}/{track} - {title}` preserves the existing behavior
- Last segment of the template becomes the file name (extension added automatically), slashes separate folder levels
- Updated all 3 download services (Deezer, Qobuz, SquidWTF) to use the template-based path builder
- Cache lookup rewritten to work with any folder structure (recursive search instead of hardcoded `artist/album/` path)
- 38 new unit tests covering template parsing, placeholder substitution, edge cases and sanitization
- `.env.example` and `docker-compose.yml` updated with the new setting

Closes #66