### PR TITLE
feat: trigger full external album download on star

### DIFF
--- a/octo-fiesta.Tests/SubsonicControllerStarTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerStarTests.cs
@@ -30,6 +30,10 @@ public class SubsonicControllerStarTests
         _mockLocalLibraryService = new Mock<ILocalLibraryService>();
         _mockDownloadService = new Mock<IDownloadService>();
         _mockLogger = new Mock<ILogger<SubsonicController>>();
+
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId(It.IsAny<string>()))
+            .Returns((string id) => ParseExternalIdForTests(id));
         
         _requestParser = new SubsonicRequestParser();
         _responseBuilder = new SubsonicResponseBuilder();
@@ -42,6 +46,25 @@ public class SubsonicControllerStarTests
             Url = "http://localhost:4533",
             EnableExternalPlaylists = true
         });
+    }
+
+    private static (bool isExternal, string? provider, string? type, string? externalId) ParseExternalIdForTests(string id)
+    {
+        if (!id.StartsWith("ext-", StringComparison.Ordinal))
+        {
+            return (false, null, null, null);
+        }
+
+        var parts = id.Split('-');
+        if (parts.Length >= 4)
+        {
+            var provider = parts[1];
+            var type = parts[2];
+            var externalId = string.Join("-", parts.Skip(3));
+            return (true, provider, type, externalId);
+        }
+
+        return (false, null, null, null);
     }
 
     private SubsonicController CreateController(
@@ -119,6 +142,47 @@ public class SubsonicControllerStarTests
     }
 
     #region Star() albumId Fallback Tests
+
+    [Fact]
+    public async Task Star_WithExternalAlbumIdInId_TriggersFullAlbumDownload()
+    {
+        // Arrange
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "ext-deezer-album-12345" }
+            });
+
+        // Act
+        var result = await controller.Star();
+
+        // Assert - should return success & trigger download based on id
+        Assert.IsType<ContentResult>(result);
+        var contentResult = (ContentResult)result;
+        Assert.Contains("starred", contentResult.Content ?? "");
+        _mockDownloadService.Verify(x => x.DownloadFullAlbumInBackground("deezer", "12345"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Star_WithExternalAlbumIdInAlbumId_AndNonAlbumInId_UsesAlbumIdFallback()
+    {
+        // Arrange
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "some-regular-id" },
+                { "albumId", "ext-qobuz-album-abc-123" }
+            });
+
+        // Act
+        var result = await controller.Star();
+
+        // Assert - should return success & trigger download based on albumId, not id
+        Assert.IsType<ContentResult>(result);
+        var contentResult = (ContentResult)result;
+        Assert.Contains("starred", contentResult.Content ?? "");
+        _mockDownloadService.Verify(x => x.DownloadFullAlbumInBackground("qobuz", "abc-123"), Times.Once);
+    }
 
     [Fact]
     public async Task Star_WithPlaylistIdInAlbumId_DetectsPlaylistAndTriggersDownload()

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -738,7 +738,7 @@ public class SubsonicController : ControllerBase
     #endregion
 
     /// <summary>
-    /// Stars (favorites) an item. For playlists, this triggers a full download.
+    /// Stars (favorites) an item. For external playlists and albums, this triggers a full download.
     /// </summary>
     [HttpGet, HttpPost]
     [Route("rest/star")]
@@ -747,16 +747,9 @@ public class SubsonicController : ControllerBase
     {
         var parameters = await ExtractAllParameters();
         var format = parameters.GetValueOrDefault("f", "xml");
-        
+
         // Check if this is a playlist
-        // Clients may send the playlist ID as "id" or "albumId" depending on the client
-        // (playlists are presented as albums, so most clients use "albumId")
-        var playlistId = parameters.GetValueOrDefault("id", "");
-        if (string.IsNullOrEmpty(playlistId) || !PlaylistIdHelper.IsExternalPlaylist(playlistId))
-        {
-            playlistId = parameters.GetValueOrDefault("albumId", "");
-        }
-        
+        var playlistId = GetExternalPlaylistIdFromStarParameters(parameters);
         if (!string.IsNullOrEmpty(playlistId) && PlaylistIdHelper.IsExternalPlaylist(playlistId))
         {
             if (_playlistSyncService == null)
@@ -782,6 +775,14 @@ public class SubsonicController : ControllerBase
             // Return success response immediately
             return _responseBuilder.CreateResponse(format, "starred", new { });
         }
+
+        var (isExternalAlbum, albumProvider, albumExternalId, rawAlbumId) = GetExternalAlbumFromStarParameters(parameters);
+        if (isExternalAlbum)
+        {
+            _logger.LogInformation("Starring external album {AlbumId}, triggering full download", rawAlbumId);
+            _downloadService.DownloadFullAlbumInBackground(albumProvider!, albumExternalId!);
+            return _responseBuilder.CreateResponse(format, "starred", new { });
+        }
         
         // For non-playlist items, relay to real Subsonic server
         try
@@ -794,6 +795,68 @@ public class SubsonicController : ControllerBase
         {
             return _responseBuilder.CreateError(format, 0, $"Error connecting to Subsonic server: {ex.Message}");
         }
+    }
+
+    private string GetExternalPlaylistIdFromStarParameters(Dictionary<string, string> parameters)
+    {
+        // Clients may send the playlist ID as "id" or "albumId" depending on the client
+        // (playlists are presented as albums, so most clients use "albumId")
+        var id = parameters.GetValueOrDefault("id", "");
+        if (!string.IsNullOrEmpty(id) && PlaylistIdHelper.IsExternalPlaylist(id))
+        {
+            return id;
+        }
+
+        var albumId = parameters.GetValueOrDefault("albumId", "");
+        if (!string.IsNullOrEmpty(albumId) && PlaylistIdHelper.IsExternalPlaylist(albumId))
+        {
+            return albumId;
+        }
+
+        return string.Empty;
+    }
+
+    private (bool IsExternalAlbum, string? Provider, string? ExternalId, string RawAlbumId) GetExternalAlbumFromStarParameters(Dictionary<string, string> parameters)
+    {
+        var id = parameters.GetValueOrDefault("id", "");
+        if (TryParseExternalAlbumId(id, out var provider, out var externalId))
+        {
+            return (true, provider, externalId, id);
+        }
+
+        var albumId = parameters.GetValueOrDefault("albumId", "");
+        if (TryParseExternalAlbumId(albumId, out provider, out externalId))
+        {
+            return (true, provider, externalId, albumId);
+        }
+
+        return (false, null, null, string.Empty);
+    }
+
+    private bool TryParseExternalAlbumId(string id, out string? provider, out string? externalId)
+    {
+        provider = null;
+        externalId = null;
+
+        if (string.IsNullOrWhiteSpace(id) || PlaylistIdHelper.IsExternalPlaylist(id))
+        {
+            return false;
+        }
+
+        var (isExternal, parsedProvider, type, parsedExternalId) = _localLibraryService.ParseExternalId(id);
+        if (!isExternal || !string.Equals(type, "album", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(parsedProvider) || string.IsNullOrEmpty(parsedExternalId))
+        {
+            return false;
+        }
+
+        provider = parsedProvider;
+        externalId = parsedExternalId;
+        return true;
     }
 
     // Generic endpoint to handle all subsonic API calls

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -160,6 +160,27 @@ public abstract class BaseDownloadService : IDownloadService
         });
     }
 
+    public void DownloadFullAlbumInBackground(string externalProvider, string albumExternalId)
+    {
+        if (externalProvider != ProviderName)
+        {
+            Logger.LogWarning("Provider '{Provider}' is not supported for album download", externalProvider);
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await DownloadFullAlbumAsync(albumExternalId);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to download full album {AlbumId}", albumExternalId);
+            }
+        });
+    }
+
     #endregion
 
     #region Template Methods (to be implemented by subclasses)
@@ -492,21 +513,38 @@ public abstract class BaseDownloadService : IDownloadService
 
     protected async Task DownloadRemainingAlbumTracksAsync(string albumExternalId, string excludeTrackExternalId, CancellationToken cancellationToken = default)
     {
-        Logger.LogInformation("Starting background download for album {AlbumId} (excluding track {TrackId})",
-            albumExternalId, excludeTrackExternalId);
+        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId, cancellationToken);
+    }
+
+    protected async Task DownloadFullAlbumAsync(string albumExternalId, CancellationToken cancellationToken = default)
+    {
+        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId: null, cancellationToken);
+    }
+
+    private async Task DownloadAlbumTracksAsync(string albumExternalId, string? excludeTrackExternalId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(excludeTrackExternalId))
+        {
+            Logger.LogInformation("Starting background full album download for album {AlbumId}", albumExternalId);
+        }
+        else
+        {
+            Logger.LogInformation("Starting background download for album {AlbumId} (excluding track {TrackId})",
+                albumExternalId, excludeTrackExternalId);
+        }
 
         var album = await MetadataService.GetAlbumAsync(ProviderName, albumExternalId);
         if (album == null)
         {
-            Logger.LogWarning("Album {AlbumId} not found, cannot download remaining tracks", albumExternalId);
+            Logger.LogWarning("Album {AlbumId} not found, cannot download tracks", albumExternalId);
             return;
         }
 
         var tracksToDownload = album.Songs
-            .Where(s => s.ExternalId != excludeTrackExternalId && !string.IsNullOrEmpty(s.ExternalId))
+            .Where(s => !string.IsNullOrEmpty(s.ExternalId) && (string.IsNullOrEmpty(excludeTrackExternalId) || s.ExternalId != excludeTrackExternalId))
             .ToList();
 
-        Logger.LogInformation("Found {Count} additional tracks to download for album '{AlbumTitle}'",
+        Logger.LogInformation("Found {Count} tracks to download for album '{AlbumTitle}'",
             tracksToDownload.Count, album.Title);
 
         foreach (var track in tracksToDownload)

--- a/octo-fiesta/Services/IDownloadService.cs
+++ b/octo-fiesta/Services/IDownloadService.cs
@@ -36,6 +36,13 @@ public interface IDownloadService
     /// <param name="albumExternalId">The album ID on the external provider</param>
     /// <param name="excludeTrackExternalId">The track ID to exclude (already downloaded)</param>
     void DownloadRemainingAlbumTracksInBackground(string externalProvider, string albumExternalId, string excludeTrackExternalId);
+
+    /// <summary>
+    /// Downloads all tracks from an album in background.
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, spotify)</param>
+    /// <param name="albumExternalId">The album ID on the external provider</param>
+    void DownloadFullAlbumInBackground(string externalProvider, string albumExternalId);
     
     /// <summary>
     /// Checks if a song is currently being downloaded


### PR DESCRIPTION
- extend /rest/star handling to also detect external album IDs and start background full album download
- refactor album background download method to be used by both full and remaining-track downloads
- add album star trigger tests to SubsonicControllerStarTests

#### Usecases:
- you want to download a full album without having to click on every single track
- you want to add an external album to a playlist and speed up the manual process of adding the tracks to your library before you can add them to a playlist.