### PR TITLE
Proposal: refactor Error class for Result pattern

### DIFF
--- a/octo-fiesta/Services/Common/Error.cs
+++ b/octo-fiesta/Services/Common/Error.cs
@@ -36,6 +36,21 @@ public class Error(string message, Error? reason = null)
 
         return errors;
     }
+    /// <summary>
+    /// Overrides ToString()
+    /// </summary>
+    /// <returns>Error message prefixed by Error type name.</returns>
+    public override string ToString()
+    {
+        var type = GetType();
+        string? fullName = type.FullName;
+        string name = fullName?
+                    .Split(".")?[^1]?
+                    .Replace("+",".")
+                    ?? type.Name;
+
+        return $"{name}: {Message}";
+    }
 }
 #endregion Error Definition
 
@@ -78,13 +93,13 @@ public class HttpError(string message, Error? reason = null) : Error(message, re
 /// <summary>
 /// Silly demo of possible typed error usage
 /// </summary>
-public class Demo
+public static class Demo
 {
     /// <summary>
     /// Returning different implicitly converted Results
     /// with different Error subtypes
     /// </summary>
-    public Result<string> GetSongResponse(string url)
+    public static Result<string> GetSongResponse(string url)
     {
         bool responseIsSuccess = false;
         int responseCode = 404;
@@ -102,7 +117,7 @@ public class Demo
     /// <summary>
     /// Returning Error with reason. May be useful for logging and tracing.
     /// </summary>
-    public Result DownloadSong(int id)
+    public static Result DownloadSong(int id)
     {
         var res = GetSongResponse($"https://monochrome.tf/song/{id}");
         if (res.IsFailure){
@@ -114,9 +129,10 @@ public class Demo
 
     /// <summary>
     /// Checking Error Type.
+    /// Printing Error trace.
     /// </summary>
     /// <param name="ids"></param>
-    public void DownloadSongs(List<int> ids)
+    public static void DownloadSongs(List<int> ids)
     {
         foreach (int id in ids)
         {
@@ -126,9 +142,9 @@ public class Demo
                 ///
             }
 
-            if (result.Error is SquidWTFSongNotDownloaded e)
+            if (result.Error is SquidWTFSongNotDownloaded error)
             {
-                // do something with e.SongId; or with e.GetTrace()
+                error.GetTrace().ForEach(e => Console.WriteLine(e));
             }
         }
     }

--- a/octo-fiesta/Services/Common/Error.cs
+++ b/octo-fiesta/Services/Common/Error.cs
@@ -1,140 +1,138 @@
 namespace octo_fiesta.Services.Common;
 
+#region Proposed Error Class
 /// <summary>
-/// Represents a typed error with code, message, and metadata
+/// Represents a simple error with a string Error Message and optional reason.
 /// </summary>
-public class Error
+/// <param name="message">Simple string error message</param>
+/// <param name="reason">Another instance or Error which caused this Error</param>
+public class Error(string message, Error? reason = null)
 {
     /// <summary>
-    /// Unique error code identifier
+    /// Error Message
     /// </summary>
-    public string Code { get; }
-    
+    public string Message { get; } = message;
+
     /// <summary>
-    /// Human-readable error message
+    /// Error Reason.
+    /// Another instance or Error which caused this Error
     /// </summary>
-    public string Message { get; }
-    
+    public Error? Reason { get; } = reason;
+
     /// <summary>
-    /// Error type/category
+    /// Get the full chain of errors, including current one.
+    /// Current error first, original root error last.
     /// </summary>
-    public ErrorType Type { get; }
-    
-    /// <summary>
-    /// Additional metadata about the error
-    /// </summary>
-    public Dictionary<string, object>? Metadata { get; }
-    
-    private Error(string code, string message, ErrorType type, Dictionary<string, object>? metadata = null)
+    public List<Error> GetTrace()
     {
-        Code = code;
-        Message = message;
-        Type = type;
-        Metadata = metadata;
+        Error? error = this;
+        List<Error> errors = [];
+        
+        while (error is not null)
+        {
+            errors.Add(error);
+            error = error.Reason;
+        }
+
+        return errors;
     }
-    
+}
+#endregion Error Definition
+
+#region Demo
+/// <summary>
+/// Some random inheritance
+/// </summary>
+public class SquidWTFError(string message, Error? reason = null) : Error(message, reason);
+
+/// <summary>
+/// And another random inheritance with overridden constructor.
+///
+/// Yes, constructors are public, there are no static factory methods.
+/// </summary>
+public class SquidWTFSongNotDownloaded(int songId, Error? reason = null)
+    : SquidWTFError($"Failed to download song with id {songId}", reason)
+{
+    public int SongId { get; } = songId;
+}
+
+
+
+/// <summary>
+/// And better approach to organize these types of errors.
+/// Nested tree-like structure of subclasses. It may be convenient
+/// to put them into separate namespaces or something.
+///
+/// Typing and nesting hierarchy can serve as replacement for `ErrorType Type`
+/// and possibly for `string Code`.
+/// Anyways we can extend base Error with some fields and methods.
+/// </summary>
+public class HttpError(string message, Error? reason = null) : Error(message, reason)
+{
+    public class NotFound(string message) : HttpError(message, null);
+    public class Internal(string message) : HttpError(message, null);
+    public class Unauthorized(string message) : HttpError(message, null);
+}
+
+
+/// <summary>
+/// Silly demo of possible typed error usage
+/// </summary>
+public class Demo
+{
     /// <summary>
-    /// Creates a Not Found error (404)
+    /// Returning different implicitly converted Results
+    /// with different Error subtypes
     /// </summary>
-    public static Error NotFound(string message, string? code = null, Dictionary<string, object>? metadata = null)
+    public Result<string> GetSongResponse(string url)
     {
-        return new Error(code ?? "NOT_FOUND", message, ErrorType.NotFound, metadata);
+        bool responseIsSuccess = false;
+        int responseCode = 404;
+        string responseString = "";
+
+        if (responseIsSuccess) return responseString;
+
+        if (responseCode == 401) return new HttpError.Unauthorized(url);
+
+        if (responseCode == 404) return new HttpError.NotFound(url);
+
+        return new HttpError("Impossible HTTP Error happened. Panic please. Please. Wai.. shoudn't I use exceptions here?");
     }
-    
+
     /// <summary>
-    /// Creates a Validation error (400)
+    /// Returning Error with reason. May be useful for logging and tracing.
     /// </summary>
-    public static Error Validation(string message, string? code = null, Dictionary<string, object>? metadata = null)
+    public Result DownloadSong(int id)
     {
-        return new Error(code ?? "VALIDATION_ERROR", message, ErrorType.Validation, metadata);
+        var res = GetSongResponse($"https://monochrome.tf/song/{id}");
+        if (res.IsFailure){
+            return new SquidWTFSongNotDownloaded(id, res.Error);
+        }
+        // do some downloading job
+        return Result.Success();
     }
-    
+
     /// <summary>
-    /// Creates an Unauthorized error (401)
+    /// Checking Error Type.
     /// </summary>
-    public static Error Unauthorized(string message, string? code = null, Dictionary<string, object>? metadata = null)
+    /// <param name="ids"></param>
+    public void DownloadSongs(List<int> ids)
     {
-        return new Error(code ?? "UNAUTHORIZED", message, ErrorType.Unauthorized, metadata);
-    }
-    
-    /// <summary>
-    /// Creates a Forbidden error (403)
-    /// </summary>
-    public static Error Forbidden(string message, string? code = null, Dictionary<string, object>? metadata = null)
-    {
-        return new Error(code ?? "FORBIDDEN", message, ErrorType.Forbidden, metadata);
-    }
-    
-    /// <summary>
-    /// Creates a Conflict error (409)
-    /// </summary>
-    public static Error Conflict(string message, string? code = null, Dictionary<string, object>? metadata = null)
-    {
-        return new Error(code ?? "CONFLICT", message, ErrorType.Conflict, metadata);
-    }
-    
-    /// <summary>
-    /// Creates an Internal Server Error (500)
-    /// </summary>
-    public static Error Internal(string message, string? code = null, Dictionary<string, object>? metadata = null)
-    {
-        return new Error(code ?? "INTERNAL_ERROR", message, ErrorType.Internal, metadata);
-    }
-    
-    /// <summary>
-    /// Creates an External Service Error (502/503)
-    /// </summary>
-    public static Error ExternalService(string message, string? code = null, Dictionary<string, object>? metadata = null)
-    {
-        return new Error(code ?? "EXTERNAL_SERVICE_ERROR", message, ErrorType.ExternalService, metadata);
-    }
-    
-    /// <summary>
-    /// Creates a custom error with specified type
-    /// </summary>
-    public static Error Custom(string code, string message, ErrorType type, Dictionary<string, object>? metadata = null)
-    {
-        return new Error(code, message, type, metadata);
+        foreach (int id in ids)
+        {
+            var result = DownloadSong(id);
+            if (result.IsSuccess)
+            {
+                ///
+            }
+
+            if (result.Error is SquidWTFSongNotDownloaded e)
+            {
+                // do something with e.SongId; or with e.GetTrace()
+            }
+        }
     }
 }
 
-/// <summary>
-/// Categorizes error types for appropriate HTTP status code mapping
-/// </summary>
-public enum ErrorType
-{
-    /// <summary>
-    /// Validation error (400 Bad Request)
-    /// </summary>
-    Validation,
-    
-    /// <summary>
-    /// Resource not found (404 Not Found)
-    /// </summary>
-    NotFound,
-    
-    /// <summary>
-    /// Authentication required (401 Unauthorized)
-    /// </summary>
-    Unauthorized,
-    
-    /// <summary>
-    /// Insufficient permissions (403 Forbidden)
-    /// </summary>
-    Forbidden,
-    
-    /// <summary>
-    /// Resource conflict (409 Conflict)
-    /// </summary>
-    Conflict,
-    
-    /// <summary>
-    /// Internal server error (500 Internal Server Error)
-    /// </summary>
-    Internal,
-    
-    /// <summary>
-    /// External service error (502 Bad Gateway / 503 Service Unavailable)
-    /// </summary>
-    ExternalService
-}
+
+#endregion


### PR DESCRIPTION
- refactor: simplify errors for result pattern

---

Hi! 
I'm sorry in advance for my inability to fully express myself in English. 

I'm currently working on integrating another music streaming provider with octo-fiesta. 
I read the project wiki and it says about using Result pattern. 

At this moment it felt like a good idea to use it. But I didn't find any usages of Result, Result<T>, Error across the entire repository. 
Then I looked into the actual code of Error class and saw that I can't use it within my services. 

I don't usually speak C# so I can miss something, but it looks not very extensible and tightly coupled to the concepts of HTTP. 

I'm actually OK with `if (res is null)  {log error and return null}`. And a single simple untyped `public class Error(string Message)` looks fine for me as a replacement for `null`s. But if typing is needed, here in this PR is a demo of possible Error types organizing. 

Or maybe it is better to introduce some library like [FluentResults](https://github.com/altmann/FluentResults)? 

Sorry if PR is a wrong place for discussions (maybe i should open an issue/discussion instead?) but discussing code with code preview feels more effective. 

I'm ready to remove all demo parts and fix issues if needed when you reply. 