### PR TITLE
feat(scrobble): resolve external song IDs to local Subsonic IDs before proxying

### DIFF
--- a/octo-fiesta.Tests/SubsonicControllerScrobbleTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerScrobbleTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using octo_fiesta.Controllers;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Services;
+using octo_fiesta.Services.Local;
+using octo_fiesta.Services.Subsonic;
+using System.Net;
+
+namespace octo_fiesta.Tests;
+
+public class SubsonicControllerScrobbleTests
+{
+    private readonly Mock<IMusicMetadataService> _mockMetadataService;
+    private readonly Mock<ILocalLibraryService> _mockLocalLibraryService;
+    private readonly Mock<IDownloadService> _mockDownloadService;
+    private readonly Mock<ILogger<SubsonicController>> _mockLogger;
+    private readonly SubsonicRequestParser _requestParser;
+    private readonly SubsonicResponseBuilder _responseBuilder;
+    private readonly SubsonicModelMapper _modelMapper;
+    private readonly IOptions<SubsonicSettings> _settings;
+
+    public SubsonicControllerScrobbleTests()
+    {
+        _mockMetadataService = new Mock<IMusicMetadataService>();
+        _mockLocalLibraryService = new Mock<ILocalLibraryService>();
+        _mockDownloadService = new Mock<IDownloadService>();
+        _mockLogger = new Mock<ILogger<SubsonicController>>();
+
+        _requestParser = new SubsonicRequestParser();
+        _responseBuilder = new SubsonicResponseBuilder();
+        _modelMapper = new SubsonicModelMapper(
+            _responseBuilder,
+            new Mock<ILogger<SubsonicModelMapper>>().Object);
+
+        _settings = Options.Create(new SubsonicSettings
+        {
+            Url = "http://localhost:4533"
+        });
+    }
+
+    private SubsonicController CreateController(
+        Dictionary<string, string> queryParams,
+        HttpResponseMessage proxyResponse,
+        Action<HttpRequestMessage>? captureRequest = null)
+    {
+        // We can't easily mock SubsonicProxyService (concrete class with HttpClient dependency)
+        // So we create a real one with a mocked HttpClient
+        var mockHttpHandler = new Mock<HttpMessageHandler>();
+        mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captureRequest?.Invoke(req))
+            .ReturnsAsync(proxyResponse);
+
+        var httpClient = new HttpClient(mockHttpHandler.Object);
+        var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        var proxyService = new SubsonicProxyService(
+            mockHttpClientFactory.Object, _settings, httpContextAccessor);
+
+        var controller = new SubsonicController(
+            _settings,
+            _mockMetadataService.Object,
+            _mockLocalLibraryService.Object,
+            _mockDownloadService.Object,
+            _requestParser,
+            _responseBuilder,
+            _modelMapper,
+            proxyService,
+            _mockLogger.Object,
+            playlistSyncService: null);
+
+        // Set up HttpContext with query parameters
+        var httpContext = new DefaultHttpContext();
+        var queryString = string.Join("&", queryParams.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        httpContext.Request.QueryString = new QueryString("?" + queryString);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return controller;
+    }
+
+    [Fact]
+    public async Task Scrobble_WithResolvableExternalId_UsesLocalId()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-qobuz-song-123"))
+            .Returns((true, "qobuz", "song", "123"));
+        _mockLocalLibraryService
+            .Setup(x => x.GetLocalIdForExternalSongAsync("qobuz", "123"))
+            .ReturnsAsync("9981");
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "ext-qobuz-song-123" },
+                { "submission", "true" },
+                { "f", "json" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.Scrobble();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/scrobble", requestUrl);
+        Assert.Contains("id=9981", requestUrl);
+        Assert.DoesNotContain("ext-qobuz-song-123", requestUrl);
+    }
+
+    [Fact]
+    public async Task Scrobble_WithUnresolvableExternalId_FallsBackToExternalId()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-deezer-song-999"))
+            .Returns((true, "deezer", "song", "999"));
+        _mockLocalLibraryService
+            .Setup(x => x.GetLocalIdForExternalSongAsync("deezer", "999"))
+            .ReturnsAsync((string?)null);
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "ext-deezer-song-999" },
+                { "submission", "true" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.Scrobble();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/scrobble", requestUrl);
+        Assert.Contains("id=ext-deezer-song-999", requestUrl);
+    }
+}

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -797,6 +797,48 @@ public class SubsonicController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Scrobbles a song. External song IDs are resolved to local Subsonic IDs when possible.
+    /// </summary>
+    [HttpGet, HttpPost]
+    [Route("rest/scrobble")]
+    [Route("rest/scrobble.view")]
+    public async Task<IActionResult> Scrobble()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+
+        if (parameters.TryGetValue("id", out var id) && !string.IsNullOrWhiteSpace(id))
+        {
+            var (isExternal, provider, type, externalId) = _localLibraryService.ParseExternalId(id);
+            if (isExternal && string.Equals(type, "song", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(provider) && !string.IsNullOrEmpty(externalId))
+            {
+                var localId = await _localLibraryService.GetLocalIdForExternalSongAsync(provider, externalId);
+                if (!string.IsNullOrEmpty(localId))
+                {
+                    _logger.LogInformation("Resolved scrobble ID {ExternalId} to local ID {LocalId}", id, localId);
+                    parameters["id"] = localId;
+                }
+                else
+                {
+                    _logger.LogInformation("Could not resolve external scrobble ID {ExternalId} to a local ID", id);
+                }
+            }
+        }
+
+        try
+        {
+            var result = await _proxyService.RelayAsync("rest/scrobble", parameters);
+            var contentType = result.ContentType ?? $"application/{format}";
+            return File(result.Body, contentType);
+        }
+        catch (HttpRequestException ex)
+        {
+            return _responseBuilder.CreateError(format, 0, $"Error connecting to Subsonic server: {ex.Message}");
+        }
+    }
+
     private string GetExternalPlaylistIdFromStarParameters(Dictionary<string, string> parameters)
     {
         // Clients may send the playlist ID as "id" or "albumId" depending on the client

--- a/octo-fiesta/Services/Local/LocalLibraryService.cs
+++ b/octo-fiesta/Services/Local/LocalLibraryService.cs
@@ -6,6 +6,7 @@ using octo_fiesta.Models.Download;
 using octo_fiesta.Models.Search;
 using octo_fiesta.Models.Subsonic;
 using octo_fiesta.Services;
+using octo_fiesta.Services.Common;
 
 namespace octo_fiesta.Services.Local;
 
@@ -108,10 +109,121 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
 
     public async Task<string?> GetLocalIdForExternalSongAsync(string externalProvider, string externalId)
     {
-        // For now, return null as we don't yet have integration
-        // with the Subsonic server to retrieve local ID after scan
-        await Task.CompletedTask;
-        return null;
+        var mappings = await LoadMappingsAsync();
+        var key = $"{externalProvider}:{externalId}";
+
+        if (!mappings.TryGetValue(key, out var mapping) || !File.Exists(mapping.LocalPath))
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(mapping.LocalSubsonicId))
+        {
+            return mapping.LocalSubsonicId;
+        }
+
+        try
+        {
+            var queryText = string.Join(" ", new[] { mapping.Artist, mapping.Title }.Where(s => !string.IsNullOrWhiteSpace(s)));
+            if (string.IsNullOrWhiteSpace(queryText))
+            {
+                return null;
+            }
+
+            var authQuery = BuildAuthQuery();
+            var searchUrl = $"{_subsonicSettings.Url}/rest/search3?f=json&songCount=10&albumCount=0&artistCount=0&query={Uri.EscapeDataString(queryText)}{authQuery}";
+
+            var response = await _httpClient.GetAsync(searchUrl);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Could not resolve local Subsonic ID for {Provider}:{ExternalId}. search3 returned {StatusCode}",
+                    externalProvider, externalId, response.StatusCode);
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(content);
+
+            if (!doc.RootElement.TryGetProperty("subsonic-response", out var subsonicResponse) ||
+                !subsonicResponse.TryGetProperty("searchResult3", out var searchResult) ||
+                !searchResult.TryGetProperty("song", out var songNode))
+            {
+                return null;
+            }
+
+            var titleKey = StringNormalizer.CreateComparisonKey(mapping.Title);
+            var artistKey = StringNormalizer.CreateComparisonKey(mapping.Artist);
+            var albumKey = StringNormalizer.CreateComparisonKey(mapping.Album);
+
+            string? matchedId = null;
+
+            foreach (var songElement in EnumerateSongs(songNode))
+            {
+                var candidateId = songElement.TryGetProperty("id", out var idEl) ? idEl.ToString() : null;
+                if (string.IsNullOrEmpty(candidateId))
+                {
+                    continue;
+                }
+
+                var candidateTitleKey = StringNormalizer.CreateComparisonKey(songElement.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : null);
+                var candidateArtistKey = StringNormalizer.CreateComparisonKey(songElement.TryGetProperty("artist", out var artistEl) ? artistEl.GetString() : null);
+                var candidateAlbumKey = StringNormalizer.CreateComparisonKey(songElement.TryGetProperty("album", out var albumEl) ? albumEl.GetString() : null);
+
+                var titleMatches = !string.IsNullOrEmpty(titleKey) && titleKey == candidateTitleKey;
+                var artistMatches = !string.IsNullOrEmpty(artistKey) && artistKey == candidateArtistKey;
+                var albumMatches = !string.IsNullOrEmpty(albumKey) && albumKey == candidateAlbumKey;
+
+                if ((titleMatches && artistMatches) || (titleMatches && albumMatches))
+                {
+                    matchedId = candidateId;
+                    break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(matchedId))
+            {
+                return null;
+            }
+
+            await _lock.WaitAsync();
+            try
+            {
+                if (mappings.TryGetValue(key, out var mappingToUpdate))
+                {
+                    mappingToUpdate.LocalSubsonicId = matchedId;
+                    await SaveMappingsAsync(mappings);
+                }
+            }
+            finally
+            {
+                _lock.Release();
+            }
+
+            _logger.LogInformation("Resolved local Subsonic ID {LocalId} for external song {Provider}:{ExternalId}",
+                matchedId, externalProvider, externalId);
+            return matchedId;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve local Subsonic ID for external song {Provider}:{ExternalId}",
+                externalProvider, externalId);
+            return null;
+        }
+    }
+
+    private static IEnumerable<JsonElement> EnumerateSongs(JsonElement songNode)
+    {
+        if (songNode.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var song in songNode.EnumerateArray())
+            {
+                yield return song;
+            }
+        }
+        else if (songNode.ValueKind == JsonValueKind.Object)
+        {
+            yield return songNode;
+        }
     }
 
     public (bool isExternal, string? provider, string? externalId) ParseSongId(string songId)


### PR DESCRIPTION
- add rest/scrobble endpoint
- detect external song IDs in scrobble endpoint and attempt local ID resolution
- forward scrobble with resolved local ID when available
- fallback to original external ID when resolution failed
- implement best-effort local ID lookup in LocalLibraryService via Subsonic search3
- cache resolved local ID in mappings
- add tests for resolved and fallback scrobble flows

Let me know what you think about the GetLocalIdForExternalSongAsync implementation.

Closes #158 