### PR TITLE
fix(startup): warn on source-incompatible SquidWTF quality values

### DIFF
--- a/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
@@ -30,24 +30,16 @@ public class SquidWTFStartupValidator : BaseStartupValidator
         Console.WriteLine();
 
         var source = _settings.Source ?? "Qobuz";
-        var quality = _settings.Quality?.ToUpperInvariant() switch
-        {
-            "FLAC" => "LOSSLESS",
-            "HI_RES" => "HI_RES_LOSSLESS",
-            "LOSSLESS" => "LOSSLESS",
-            "HIGH" => "HIGH",
-            "LOW" => "LOW",
-            "27" => "FLAC 24-bit/192kHz",
-            "7" => "FLAC 24-bit/96kHz",
-            "6" => "FLAC 16-bit",
-            "5" => "MP3 320kbps",
-            _ => source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase) 
-                ? "FLAC 24-bit/192kHz (default)" 
-                : "LOSSLESS (default)"
-        };
+        var configuredQuality = _settings.Quality;
+        var (quality, usedDefaultFallback) = GetEffectiveQualityLabel(source, configuredQuality);
 
         WriteStatus("SquidWTF Source", source, ConsoleColor.Cyan);
         WriteStatus("SquidWTF Quality", quality, ConsoleColor.Cyan);
+        if (usedDefaultFallback && !string.IsNullOrWhiteSpace(configuredQuality))
+        {
+            WriteStatus("SquidWTF Quality Warning", "INCOMPATIBLE CONFIG", ConsoleColor.Yellow);
+            WriteDetail($"Quality '{configuredQuality}' is not valid for source '{source}'. Falling back to default quality.");
+        }
         
         if (_settings.InstanceTimeoutSeconds > 0)
         {
@@ -192,5 +184,32 @@ public class SquidWTFStartupValidator : BaseStartupValidator
             WriteStatus("Search Functionality", "ERROR", ConsoleColor.Yellow);
             WriteDetail($"Could not verify search: {ex.Message}");
         }
+    }
+
+    private static (string Label, bool UsedDefaultFallback) GetEffectiveQualityLabel(string source, string? configuredQuality)
+    {
+        var sourceIsQobuz = source.Equals("Qobuz", StringComparison.OrdinalIgnoreCase);
+        var quality = configuredQuality?.ToUpperInvariant();
+
+        if (sourceIsQobuz)
+        {
+            return quality switch
+            {
+                "27" => ("FLAC 24-bit/192kHz", false),
+                "7" => ("FLAC 24-bit/96kHz", false),
+                "6" => ("FLAC 16-bit", false),
+                "5" => ("MP3 320kbps", false),
+                _ => ("FLAC 24-bit/192kHz (default)", true)
+            };
+        }
+
+        return quality switch
+        {
+            "FLAC" or "LOSSLESS" => ("LOSSLESS", false),
+            "HI_RES" => ("HI_RES_LOSSLESS", false),
+            "HIGH" => ("HIGH", false),
+            "LOW" => ("LOW", false),
+            _ => ("LOSSLESS (default)", true)
+        };
     }
 }

--- a/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFStartupValidator.cs
@@ -195,21 +195,21 @@ public class SquidWTFStartupValidator : BaseStartupValidator
         {
             return quality switch
             {
-                "27" => ("FLAC 24-bit/192kHz", false),
-                "7" => ("FLAC 24-bit/96kHz", false),
-                "6" => ("FLAC 16-bit", false),
-                "5" => ("MP3 320kbps", false),
+                "FLAC_24_192" or "FLAC_24" or "27" => ("FLAC 24-bit/192kHz", false),
+                "FLAC_24_96" or "7" => ("FLAC 24-bit/96kHz", false),
+                "FLAC_16" or "FLAC" or "6" => ("FLAC 16-bit", false),
+                "MP3_320" or "MP3" or "5" => ("MP3 320kbps", false),
                 _ => ("FLAC 24-bit/192kHz (default)", true)
             };
         }
 
         return quality switch
         {
-            "FLAC" or "LOSSLESS" => ("LOSSLESS", false),
-            "HI_RES" => ("HI_RES_LOSSLESS", false),
-            "HIGH" => ("HIGH", false),
-            "LOW" => ("LOW", false),
-            _ => ("LOSSLESS (default)", true)
+            "HI_RES_LOSSLESS" or "HI_RES" or "FLAC_24" => ("HI_RES_LOSSLESS", false),
+            "LOSSLESS" or "FLAC" or "FLAC_16" => ("LOSSLESS", false),
+            "HIGH" or "AAC_320" or "AAC_HIGH" => ("HIGH", false),
+            "LOW" or "AAC_96" or "AAC_LOW" => ("LOW", false),
+            _ => ("HI_RES_LOSSLESS (default)", true)
         };
     }
 }


### PR DESCRIPTION
- refactor SquidWTF startup quality parsing to be source-specific
- add startup warning when a configured quality is incompatible and fallback is used
- prevent silent misconfiguration

While setting stuff for dev up, I accidentally used a SquidWTF Quobuz quality setting while Tidal was configured.
Then I wondered why octo-fiesta was uploading .flac files, while the startup config logging showed mp3 configured quality.
This pull request should warn others about this kind of misconfiguration.

<table>
  <tr>
    <td align="center"><b>Before (Silent Fallback)</b></td>
    <td align="center"><b>After (Clear Warning)</b></td>
  </tr>
  <tr>
    <td>
      <img width="400" src="https://github.com/user-attachments/assets/d471fc97-24d5-47bf-9252-1f72d1599901" />
    </td>
    <td>
      <img width="400" src="https://github.com/user-attachments/assets/e497dd35-4be1-46a6-bba3-ca4856b5cb60" />
    </td>
  </tr>
  <tr>
    <td>Logs show a configured quality, but the downloader uses the default.</td>
    <td>Clear warning indicating the mismatch.</td>
  </tr>
</table>
