### PR TITLE
feat: resolve external song ids in star and unstar endpoints

### DIFF
--- a/octo-fiesta.Tests/SubsonicControllerStarUnstarExternalIdTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerStarUnstarExternalIdTests.cs
@@ -14,7 +14,7 @@ using System.Net;
 
 namespace octo_fiesta.Tests;
 
-public class SubsonicControllerScrobbleTests
+public class SubsonicControllerStarUnstarExternalIdTests
 {
     private readonly Mock<IMusicMetadataService> _mockMetadataService;
     private readonly Mock<ILocalLibraryService> _mockLocalLibraryService;
@@ -25,7 +25,7 @@ public class SubsonicControllerScrobbleTests
     private readonly SubsonicModelMapper _modelMapper;
     private readonly IOptions<SubsonicSettings> _settings;
 
-    public SubsonicControllerScrobbleTests()
+    public SubsonicControllerStarUnstarExternalIdTests()
     {
         _mockMetadataService = new Mock<IMusicMetadataService>();
         _mockLocalLibraryService = new Mock<ILocalLibraryService>();
@@ -103,7 +103,7 @@ public class SubsonicControllerScrobbleTests
     }
 
     [Fact]
-    public async Task Scrobble_WithResolvableExternalId_UsesLocalId()
+    public async Task Star_WithResolvableExternalSongId_UsesLocalId()
     {
         // Arrange
         _mockLocalLibraryService
@@ -118,7 +118,6 @@ public class SubsonicControllerScrobbleTests
             queryParams: new Dictionary<string, string>
             {
                 { "id", "ext-qobuz-song-123" },
-                { "submission", "true" },
                 { "f", "json" }
             },
             proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
@@ -128,19 +127,19 @@ public class SubsonicControllerScrobbleTests
             captureRequest: req => capturedRequest = req);
 
         // Act
-        var result = await controller.Scrobble();
+        var result = await controller.Star();
 
         // Assert
         Assert.IsType<FileContentResult>(result);
         Assert.NotNull(capturedRequest);
         var requestUrl = capturedRequest!.RequestUri!.ToString();
-        Assert.Contains("/rest/scrobble", requestUrl);
+        Assert.Contains("/rest/star", requestUrl);
         Assert.Contains("id=9981", requestUrl);
         Assert.DoesNotContain("ext-qobuz-song-123", requestUrl);
     }
 
     [Fact]
-    public async Task Scrobble_WithUnresolvableExternalId_ReturnsErrorAndDoesNotRelay()
+    public async Task Star_WithUnresolvableExternalSongId_ReturnsErrorAndDoesNotRelay()
     {
         // Arrange
         _mockLocalLibraryService
@@ -155,17 +154,86 @@ public class SubsonicControllerScrobbleTests
             queryParams: new Dictionary<string, string>
             {
                 { "id", "ext-deezer-song-999" },
-                { "submission", "true" },
                 { "f", "xml" }
             },
             proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent("ok")
+                Content = new StringContent("{}")
             },
             captureRequest: req => capturedRequest = req);
 
         // Act
-        var result = await controller.Scrobble();
+        var result = await controller.Star();
+
+        // Assert
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Contains("status=\"failed\"", contentResult.Content ?? "");
+        Assert.Contains("code=\"70\"", contentResult.Content ?? "");
+        Assert.Null(capturedRequest);
+    }
+
+    [Fact]
+    public async Task Unstar_WithResolvableExternalSongId_UsesLocalId()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-qobuz-song-321"))
+            .Returns((true, "qobuz", "song", "321"));
+        _mockLocalLibraryService
+            .Setup(x => x.GetLocalIdForExternalSongAsync("qobuz", "321"))
+            .ReturnsAsync("2001");
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "ext-qobuz-song-321" },
+                { "f", "json" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.Unstar();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/unstar", requestUrl);
+        Assert.Contains("id=2001", requestUrl);
+        Assert.DoesNotContain("ext-qobuz-song-321", requestUrl);
+    }
+
+    [Fact]
+    public async Task Unstar_WithUnresolvableExternalSongId_ReturnsErrorAndDoesNotRelay()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-deezer-song-456"))
+            .Returns((true, "deezer", "song", "456"));
+        _mockLocalLibraryService
+            .Setup(x => x.GetLocalIdForExternalSongAsync("deezer", "456"))
+            .ReturnsAsync((string?)null);
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "id", "ext-deezer-song-456" },
+                { "f", "xml" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.Unstar();
 
         // Assert
         var contentResult = Assert.IsType<ContentResult>(result);

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -747,6 +747,7 @@ public class SubsonicController : ControllerBase
 
     /// <summary>
     /// Stars (favorites) an item. For external playlists and albums, this triggers a full download.
+    /// External song IDs are resolved to local Subsonic IDs when possible.
     /// </summary>
     [HttpGet, HttpPost]
     [Route("rest/star")]
@@ -791,11 +792,48 @@ public class SubsonicController : ControllerBase
             _downloadService.DownloadFullAlbumInBackground(albumProvider!, albumExternalId!);
             return _responseBuilder.CreateResponse(format, "starred", new { });
         }
+
+        var starResolution = await ResolveExternalSongIdIfPossible(parameters, "star");
+        if (starResolution is { IsExternalSong: true, Resolved: false })
+        {
+            return _responseBuilder.CreateError(format, 70,
+                "External song could not be starred because it is not available locally yet.");
+        }
         
         // For non-playlist items, relay to real Subsonic server
         try
         {
             var result = await _proxyService.RelayAsync("rest/star", parameters);
+            var contentType = result.ContentType ?? $"application/{format}";
+            return File(result.Body, contentType);
+        }
+        catch (HttpRequestException ex)
+        {
+            return _responseBuilder.CreateError(format, 0, $"Error connecting to Subsonic server: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Removes favorite from an item. External song IDs are resolved to local Subsonic IDs when possible.
+    /// </summary>
+    [HttpGet, HttpPost]
+    [Route("rest/unstar")]
+    [Route("rest/unstar.view")]
+    public async Task<IActionResult> Unstar()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+
+        var unstarResolution = await ResolveExternalSongIdIfPossible(parameters, "unstar");
+        if (unstarResolution is { IsExternalSong: true, Resolved: false })
+        {
+            return _responseBuilder.CreateError(format, 70,
+                "External song could not be unstarred because it is not available locally.");
+        }
+
+        try
+        {
+            var result = await _proxyService.RelayAsync("rest/unstar", parameters);
             var contentType = result.ContentType ?? $"application/{format}";
             return File(result.Body, contentType);
         }
@@ -816,23 +854,11 @@ public class SubsonicController : ControllerBase
         var parameters = await ExtractAllParameters();
         var format = parameters.GetValueOrDefault("f", "xml");
 
-        if (parameters.TryGetValue("id", out var id) && !string.IsNullOrWhiteSpace(id))
+        var scrobbleResolution = await ResolveExternalSongIdIfPossible(parameters, "scrobble");
+        if (scrobbleResolution is { IsExternalSong: true, Resolved: false })
         {
-            var (isExternal, provider, type, externalId) = _localLibraryService.ParseExternalId(id);
-            if (isExternal && string.Equals(type, "song", StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(provider) && !string.IsNullOrEmpty(externalId))
-            {
-                var localId = await _localLibraryService.GetLocalIdForExternalSongAsync(provider, externalId);
-                if (!string.IsNullOrEmpty(localId))
-                {
-                    _logger.LogInformation("Resolved scrobble ID {ExternalId} to local ID {LocalId}", id, localId);
-                    parameters["id"] = localId;
-                }
-                else
-                {
-                    _logger.LogInformation("Could not resolve external scrobble ID {ExternalId} to a local ID", id);
-                }
-            }
+            return _responseBuilder.CreateError(format, 70,
+                "External song could not be scrobbled because it is not available locally yet.");
         }
 
         try
@@ -864,6 +890,32 @@ public class SubsonicController : ControllerBase
         }
 
         return string.Empty;
+    }
+
+    private async Task<(bool IsExternalSong, bool Resolved)> ResolveExternalSongIdIfPossible(Dictionary<string, string> parameters, string endpoint)
+    {
+        if (!parameters.TryGetValue("id", out var id) || string.IsNullOrWhiteSpace(id))
+        {
+            return (false, false);
+        }
+
+        var (isExternal, provider, type, externalId) = _localLibraryService.ParseExternalId(id);
+        if (!isExternal || !string.Equals(type, "song", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrEmpty(provider) || string.IsNullOrEmpty(externalId))
+        {
+            return (false, false);
+        }
+
+        var localId = await _localLibraryService.GetLocalIdForExternalSongAsync(provider, externalId);
+        if (!string.IsNullOrEmpty(localId))
+        {
+            _logger.LogInformation("Resolved {Endpoint} ID {ExternalId} to local ID {LocalId}", endpoint, id, localId);
+            parameters["id"] = localId;
+            return (true, true);
+        }
+
+        _logger.LogInformation("Could not resolve external {Endpoint} ID {ExternalId} to a local ID", endpoint, id);
+        return (true, false);
     }
 
     private (bool IsExternalAlbum, string? Provider, string? ExternalId, string RawAlbumId) GetExternalAlbumFromStarParameters(Dictionary<string, string> parameters)


### PR DESCRIPTION
This PR adds support for starring and unstarring external song IDs, reusing the existing resolution logic from the scrobble endpoint (in a shared helper method).

#### Changes:
- add shared external song ID resolution method for star, unstar and scrobble endpoints
- return Subsonic error code 70 when an external song ID cannot be resolved
- update scrobble test to expect error if external id cannot be resolved (for consistency with star/unstar behavior)
- add external song ID resolution tests for star & unstar endpoints

#### Notice: 
External song ID resolution is only intended for songs that have already been downloaded. This feature is useful when exploring new music. It allows users to star/unstar tracks right away without having to navigate to the `Recently Added` section first. 

If used with a song that hasn't been downloaded yet, it reports an appropriate error:

<img width="321" height="114" alt="star_error" src="https://github.com/user-attachments/assets/18778569-b7c3-4724-9948-839943506509" />
