### PR TITLE
Refactor BaseDownloadService

### DIFF
--- a/octo-fiesta.Tests/BaseDownloadServiceCleanupTests.cs
+++ b/octo-fiesta.Tests/BaseDownloadServiceCleanupTests.cs
@@ -100,7 +100,7 @@ public class BaseDownloadServiceCleanupTests : IDisposable
 
         protected override string? GetTargetQuality() => null;
 
-        protected override Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+        protected override Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
         {
             LastOutputPath = Path.Combine(_testDownloadPath, "partial-file.mp3");
             File.WriteAllText(LastOutputPath, "partial");

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -336,7 +336,7 @@ public abstract class BaseDownloadService : IDownloadService
     /// <param name="forcePermanent">If true, downloads to permanent storage even in Cache mode</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Download result with local file path and quality</returns>
-    protected abstract Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken);
+    protected abstract Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken);
 
     /// <summary>
     /// Extracts the external album ID from the internal album ID format.
@@ -452,7 +452,7 @@ public abstract class BaseDownloadService : IDownloadService
             string localPath;
             await using (downloadResult.DownloadStream)
             {
-                localPath = await SaveDownloadStreamToFileAsync(downloadResult, song, cancellationToken);
+                localPath = await SaveDownloadStreamToFileAsync(downloadResult, song, isCache, cancellationToken);
             }
             song.LocalPath = localPath;
 
@@ -627,9 +627,9 @@ public abstract class BaseDownloadService : IDownloadService
     /// <param name="result">DownloadResult containing download Stream and quality string.</param>
     /// <param name="song">Song metadata to interpolate into storage template.</param>
     /// <returns></returns>
-    protected async Task<string> SaveDownloadStreamToFileAsync(DownloadResult result, Song song, CancellationToken cancellationToken)
+    protected async Task<string> SaveDownloadStreamToFileAsync(DownloadResult result, Song song, bool toCache, CancellationToken cancellationToken)
     {
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        var basePath = toCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, result.Extension, SubsonicSettings.FolderTemplate, result.DownloadedQuality);
 
         // Create directories

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -376,11 +376,19 @@ public abstract class BaseDownloadService : IDownloadService
         // Acquire lock BEFORE checking existence to prevent race conditions with concurrent requests
         await DownloadLock.WaitAsync(cancellationToken);
 
+        // Tell other concurrent tasks we are started downloading routine
+        // and keep reference to it for easy access
+        DownloadInfo ourDownloadInfo = ActiveDownloads[songId] = new()
+        {
+            SongId = songId,
+            ExternalId = externalId,
+            ExternalProvider = externalProvider,
+            Status = DownloadStatus.InProgress,
+            StartedAt = DateTime.UtcNow
+        };
+        
         try
         {
-            // If we create an ActiveDownloads entry for a quality-upgrade, keep a reference
-            // to that instance so we can identify our own marker later without special flags.
-            DownloadInfo? ourDownloadInfo = null;
             // Check if already downloaded (skip for cache mode as we want to check cache folder)
             if (!isCache)
             {
@@ -389,41 +397,38 @@ public abstract class BaseDownloadService : IDownloadService
                 {
                     // Check if we should upgrade quality
                     var targetQuality = GetTargetQuality();
-                    var shouldUpgrade = QualityHelper.ShouldUpgrade(existingMapping.DownloadedQuality, targetQuality);
+                    bool shouldUpgrade = SubsonicSettings.AutoUpgradeQuality
+                        && QualityHelper.ShouldUpgrade(existingMapping.DownloadedQuality, targetQuality);
 
-                    if (SubsonicSettings.AutoUpgradeQuality && shouldUpgrade)
-                    {
-                        Logger.LogInformation("Upgrading quality from {OldQuality} to {NewQuality} for: {Path}",
-                            existingMapping.DownloadedQuality ?? "unknown", targetQuality, existingMapping.LocalPath);
-                        var backupPath = existingMapping.LocalPath + ".backup";
-                        try
-                        {
-                            IOFile.Move(existingMapping.LocalPath, backupPath);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogWarning(ex, "Failed to create backup for quality upgrade, skipping upgrade");
-                            return existingMapping.LocalPath;
-                        }
-
-                        // Store backup path to restore on failure - register an in-progress marker so other callers know an upgrade is in progress. Keep a reference to our marker.
-                        var upgradeInfo = new DownloadInfo
-                        {
-                            SongId = songId,
-                            ExternalId = externalId,
-                            ExternalProvider = externalProvider,
-                            Status = DownloadStatus.InProgress,
-                            StartedAt = DateTime.UtcNow,
-                            BackupPath = backupPath
-                        };
-                        ActiveDownloads[songId] = upgradeInfo;
-                        ourDownloadInfo = upgradeInfo;
-                    }
-                    else
+                    // No upgrade needed – return already downloaded path
+                    if (!shouldUpgrade)
                     {
                         Logger.LogInformation("Song already downloaded: {Path}", existingMapping.LocalPath);
+                        ourDownloadInfo.Status = DownloadStatus.Completed;
+                        ourDownloadInfo.CompletedAt = DateTime.UtcNow;
+                        ourDownloadInfo.LocalPath = existingMapping.LocalPath;
                         return existingMapping.LocalPath;
                     }
+
+                    // Back up existing track for quality upgrade
+                    Logger.LogInformation("Upgrading quality from {OldQuality} to {NewQuality} for: {Path}",
+                        existingMapping.DownloadedQuality ?? "unknown", targetQuality, existingMapping.LocalPath);
+                    var backupPath = existingMapping.LocalPath + ".backup";
+                    try
+                    {
+                        IOFile.Move(existingMapping.LocalPath, backupPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning(ex, "Failed to create backup for quality upgrade, skipping upgrade");
+                        ourDownloadInfo.Status = DownloadStatus.Completed;
+                        ourDownloadInfo.CompletedAt = DateTime.UtcNow;
+                        ourDownloadInfo.LocalPath = existingMapping.LocalPath;
+                        return existingMapping.LocalPath;
+                    }
+
+                    // Store backup path to restore on failure
+                    ourDownloadInfo.BackupPath = backupPath;
                 }
             }
             else
@@ -435,6 +440,9 @@ public abstract class BaseDownloadService : IDownloadService
                     Logger.LogInformation("Song found in cache: {Path}", cachedPath);
                     // Update file access time for cache cleanup logic
                     IOFile.SetLastAccessTime(cachedPath, DateTime.UtcNow);
+                    ourDownloadInfo.Status = DownloadStatus.Completed;
+                    ourDownloadInfo.CompletedAt = DateTime.UtcNow;
+                    ourDownloadInfo.LocalPath = cachedPath;
                     return cachedPath;
                 }
             }
@@ -479,26 +487,14 @@ public abstract class BaseDownloadService : IDownloadService
                 throw new Exception("Song not found");
             }
 
-            // Only create new DownloadInfo if not already created (e.g., by upgrade logic)
-            if (!ActiveDownloads.TryGetValue(songId, out var downloadInfo))
-            {
-                downloadInfo = new DownloadInfo
-                {
-                    SongId = songId,
-                    ExternalId = externalId,
-                    ExternalProvider = externalProvider,
-                    Status = DownloadStatus.InProgress,
-                    StartedAt = DateTime.UtcNow
-                };
-                ActiveDownloads[songId] = downloadInfo;
-            }
+
 
             var downloadResult = await DownloadTrackAsync(externalId, song, forcePermanent, cancellationToken);
             var localPath = downloadResult.LocalPath;
 
-            downloadInfo.Status = DownloadStatus.Completed;
-            downloadInfo.LocalPath = localPath;
-            downloadInfo.CompletedAt = DateTime.UtcNow;
+            ourDownloadInfo.Status = DownloadStatus.Completed;
+            ourDownloadInfo.LocalPath = localPath;
+            ourDownloadInfo.CompletedAt = DateTime.UtcNow;
 
             // Invalidate the metadata path cache so subsequent requests find the newly downloaded file
             var cacheKey = $"{externalProvider}|{externalId}";
@@ -563,24 +559,21 @@ public abstract class BaseDownloadService : IDownloadService
         }
         catch (Exception ex)
         {
-            if (ActiveDownloads.TryGetValue(songId, out var downloadInfo))
-            {
-                downloadInfo.Status = DownloadStatus.Failed;
-                downloadInfo.ErrorMessage = ex.Message;
+            ourDownloadInfo.Status = DownloadStatus.Failed;
+            ourDownloadInfo.ErrorMessage = ex.Message;
 
-                // Restore backup if quality upgrade failed
-                if (!string.IsNullOrEmpty(downloadInfo.BackupPath) && IOFile.Exists(downloadInfo.BackupPath))
+            // Restore backup if quality upgrade failed
+            if (!string.IsNullOrEmpty(ourDownloadInfo.BackupPath) && IOFile.Exists(ourDownloadInfo.BackupPath))
+            {
+                try
                 {
-                    try
-                    {
-                        var originalPath = downloadInfo.BackupPath.Replace(".backup", "");
-                        IOFile.Move(downloadInfo.BackupPath, originalPath);
-                        Logger.LogInformation("Restored backup after failed quality upgrade: {Path}", originalPath);
-                    }
-                    catch (Exception restoreEx)
-                    {
-                        Logger.LogError(restoreEx, "Failed to restore backup file: {BackupPath}", downloadInfo.BackupPath);
-                    }
+                    var originalPath = ourDownloadInfo.BackupPath.Replace(".backup", "");
+                    IOFile.Move(ourDownloadInfo.BackupPath, originalPath);
+                    Logger.LogInformation("Restored backup after failed quality upgrade: {Path}", originalPath);
+                }
+                catch (Exception restoreEx)
+                {
+                    Logger.LogError(restoreEx, "Failed to restore backup file: {BackupPath}", ourDownloadInfo.BackupPath);
                 }
             }
             if (ex is OperationCanceledException)
@@ -596,19 +589,18 @@ public abstract class BaseDownloadService : IDownloadService
         finally
         {
             // Clean up backup file on success
-            if (ActiveDownloads.TryGetValue(songId, out var info) &&
-                info.Status == DownloadStatus.Completed &&
-                !string.IsNullOrEmpty(info.BackupPath) &&
-                IOFile.Exists(info.BackupPath))
+            if (ourDownloadInfo.Status == DownloadStatus.Completed &&
+                !string.IsNullOrEmpty(ourDownloadInfo.BackupPath) &&
+                IOFile.Exists(ourDownloadInfo.BackupPath))
             {
                 try
                 {
-                    IOFile.Delete(info.BackupPath);
+                    IOFile.Delete(ourDownloadInfo.BackupPath);
                     Logger.LogInformation("Deleted backup after successful quality upgrade");
                 }
                 catch (Exception deleteEx)
                 {
-                    Logger.LogWarning(deleteEx, "Failed to delete backup file: {BackupPath}", info.BackupPath);
+                    Logger.LogWarning(deleteEx, "Failed to delete backup file: {BackupPath}", ourDownloadInfo.BackupPath);
                 }
             }
 

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -323,9 +323,9 @@ public abstract class BaseDownloadService : IDownloadService
     #region Template Methods (to be implemented by subclasses)
 
     /// <summary>
-    /// Result of a track download containing path and quality info
+    /// Result of a track download containing Stream with track content, preferred filename extension and quality
     /// </summary>
-    public record DownloadResult(string LocalPath, string? DownloadedQuality);
+    public record DownloadResult(Stream DownloadStream, string Extension, string? DownloadedQuality);
 
     /// <summary>
     /// Downloads a track and saves it to disk.
@@ -447,50 +447,14 @@ public abstract class BaseDownloadService : IDownloadService
                 }
             }
 
-            // Get metadata
-            // Always fetch the full album to ensure AlbumArtist is correctly set.
-            // Without this, tracks with featured artists get filed under the track artist instead of the album artist
-            // Exception: playlists are represented as albums but should use track artist.
-            Song? song = null;
-
-            var tempSong = await MetadataService.GetSongAsync(externalProvider, externalId);
-            if (tempSong != null && !string.IsNullOrEmpty(tempSong.AlbumId)
-                && !PlaylistIdHelper.IsExternalPlaylist(tempSong.AlbumId))
+            Song song = await GetSongMetadataForTrackAsync(externalProvider, externalId);
+            var downloadResult = await DownloadTrackAsync(externalId, song, cancellationToken);
+            string localPath;
+            await using (downloadResult.DownloadStream)
             {
-                var albumExternalId = ExtractExternalIdFromAlbumId(tempSong.AlbumId);
-                if (!string.IsNullOrEmpty(albumExternalId))
-                {
-                    // Get full album with correct AlbumArtist
-                    var album = await MetadataService.GetAlbumAsync(externalProvider, albumExternalId);
-                    if (album != null)
-                    {
-                        // Find the track in the album to get full metadata including AlbumArtist
-                        song = album.Songs.FirstOrDefault(s => s.ExternalId == externalId);
-
-                        // If track not found in album (e.g., bonus track), use tempSong with album artist
-                        if (song == null && !string.IsNullOrEmpty(album.Artist))
-                        {
-                            tempSong.AlbumArtist = album.Artist;
-                        }
-                    }
-                }
+                localPath = await SaveDownloadStreamToFileAsync(downloadResult, song, cancellationToken);
             }
-
-            // Use individual song if album fetch didn't find it
-            if (song == null)
-            {
-                song = tempSong ?? await MetadataService.GetSongAsync(externalProvider, externalId);
-            }
-
-            if (song == null)
-            {
-                throw new Exception("Song not found");
-            }
-
-
-
-            var downloadResult = await DownloadTrackAsync(externalId, song, forcePermanent, cancellationToken);
-            var localPath = downloadResult.LocalPath;
+            song.LocalPath = localPath;
 
             ourDownloadInfo.Status = DownloadStatus.Completed;
             ourDownloadInfo.LocalPath = localPath;
@@ -499,8 +463,6 @@ public abstract class BaseDownloadService : IDownloadService
             // Invalidate the metadata path cache so subsequent requests find the newly downloaded file
             var cacheKey = $"{externalProvider}|{externalId}";
             _metadataPathCache.TryRemove(cacheKey, out _);
-
-            song.LocalPath = localPath;
 
             // Check if this track belongs to a playlist and update M3U
             if (PlaylistSyncService != null)
@@ -605,6 +567,95 @@ public abstract class BaseDownloadService : IDownloadService
             }
 
             DownloadLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Gets Song metadata for specified track.
+    /// Used to create download file path with respect to storage template
+    /// and to write metadata to song file.
+    /// </summary>
+    protected async Task<Song> GetSongMetadataForTrackAsync(string externalProvider, string externalId)
+    {
+        // Always fetch the full album to ensure AlbumArtist is correctly set.
+        // Without this, tracks with featured artists get filed under the track artist instead of the album artist
+        // Exception: playlists are represented as albums but should use track artist.
+        Song? song = null;
+
+        var tempSong = await MetadataService.GetSongAsync(externalProvider, externalId);
+        if (tempSong != null && !string.IsNullOrEmpty(tempSong.AlbumId)
+            && !PlaylistIdHelper.IsExternalPlaylist(tempSong.AlbumId))
+        {
+            var albumExternalId = ExtractExternalIdFromAlbumId(tempSong.AlbumId);
+            if (!string.IsNullOrEmpty(albumExternalId))
+            {
+                // Get full album with correct AlbumArtist
+                var album = await MetadataService.GetAlbumAsync(externalProvider, albumExternalId);
+                if (album != null)
+                {
+                    // Find the track in the album to get full metadata including AlbumArtist
+                    song = album.Songs.FirstOrDefault(s => s.ExternalId == externalId);
+
+                    // If track not found in album (e.g., bonus track), use tempSong with album artist
+                    if (song == null && !string.IsNullOrEmpty(album.Artist))
+                    {
+                        tempSong.AlbumArtist = album.Artist;
+                    }
+                }
+            }
+        }
+
+        // Use individual song if album fetch didn't find it
+        if (song == null)
+        {
+            song = tempSong ?? await MetadataService.GetSongAsync(externalProvider, externalId);
+        }
+
+        if (song == null)
+        {
+            throw new Exception("Song not found");
+        }
+
+        return song;
+    }
+
+    /// <summary>
+    /// Takes DownloadResult provided by specific provider and saves it to file
+    /// with respect to storage template and storage mode.
+    /// Writes Song metadata to created file.
+    /// </summary>
+    /// <param name="result">DownloadResult containing download Stream and quality string.</param>
+    /// <param name="song">Song metadata to interpolate into storage template.</param>
+    /// <returns></returns>
+    protected async Task<string> SaveDownloadStreamToFileAsync(DownloadResult result, Song song, CancellationToken cancellationToken)
+    {
+        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        var outputPath = PathHelper.BuildTrackPath(basePath, song, result.Extension, SubsonicSettings.FolderTemplate, result.DownloadedQuality);
+
+        // Create directories
+        var albumFolder = Path.GetDirectoryName(outputPath)!;
+        EnsureDirectoryExists(albumFolder);
+
+        // Resolve unique path if file already exists
+        outputPath = PathHelper.ResolveUniquePath(outputPath);
+
+        try
+        {
+            // Download the file
+            await using var outputFile = IOFile.Create(outputPath);
+            await result.DownloadStream.CopyToAsync(outputFile, cancellationToken);
+            await outputFile.DisposeAsync();
+            Logger.LogInformation("Downloaded file to: {Path}", outputPath);
+
+            // Write metadata
+            await WriteMetadataAsync(outputPath, song, cancellationToken);
+
+            return outputPath;
+        }
+        catch
+        {
+            TryDeleteIncompleteFile(outputPath);
+            throw;
         }
     }
 

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -393,25 +393,6 @@ public abstract class BaseDownloadService : IDownloadService
 
                     if (SubsonicSettings.AutoUpgradeQuality && shouldUpgrade)
                     {
-                        // Check if another upgrade is already in progress for this song
-                        if (ActiveDownloads.TryGetValue(songId, out var existingDownload) && existingDownload.Status == DownloadStatus.InProgress)
-                        {
-                            Logger.LogInformation("Upgrade already in progress for {SongId}, waiting...", songId);
-                            DownloadLock.Release();
-
-                            while (ActiveDownloads.TryGetValue(songId, out existingDownload) && existingDownload.Status == DownloadStatus.InProgress)
-                            {
-                                await Task.Delay(500, cancellationToken);
-                            }
-
-                            if (existingDownload?.Status == DownloadStatus.Completed && existingDownload.LocalPath != null)
-                            {
-                                return existingDownload.LocalPath;
-                            }
-
-                            throw new Exception(existingDownload?.ErrorMessage ?? "Upgrade failed");
-                        }
-
                         Logger.LogInformation("Upgrading quality from {OldQuality} to {NewQuality} for: {Path}",
                             existingMapping.DownloadedQuality ?? "unknown", targetQuality, existingMapping.LocalPath);
                         var backupPath = existingMapping.LocalPath + ".backup";
@@ -458,33 +439,6 @@ public abstract class BaseDownloadService : IDownloadService
                 }
             }
 
-            // Check if download in progress. If the in-progress marker belongs to our
-            // current upgrade flow (ourDownloadInfo), do not wait on it.
-            if (ActiveDownloads.TryGetValue(songId, out var activeDownload) && activeDownload.Status == DownloadStatus.InProgress)
-            {
-                if (ourDownloadInfo != null && ReferenceEquals(activeDownload, ourDownloadInfo))
-                {
-                    // This is our own marker created for a quality-upgrade; proceed without waiting.
-                }
-                else
-                {
-                    Logger.LogInformation("Download already in progress for {SongId}, waiting...", songId);
-                    // Release lock while waiting
-                    DownloadLock.Release();
-
-                    while (ActiveDownloads.TryGetValue(songId, out activeDownload) && activeDownload.Status == DownloadStatus.InProgress)
-                    {
-                        await Task.Delay(500, cancellationToken);
-                    }
-
-                    if (activeDownload?.Status == DownloadStatus.Completed && activeDownload.LocalPath != null)
-                    {
-                        return activeDownload.LocalPath;
-                    }
-
-                    throw new Exception(activeDownload?.ErrorMessage ?? "Download failed");
-                }
-            }
             // Get metadata
             // Always fetch the full album to ensure AlbumArtist is correctly set.
             // Without this, tracks with featured artists get filed under the track artist instead of the album artist

--- a/octo-fiesta/Services/Common/HttpResponseStream.cs
+++ b/octo-fiesta/Services/Common/HttpResponseStream.cs
@@ -1,0 +1,69 @@
+namespace octo_fiesta.Services.Common;
+
+/// <summary>
+/// HttpResponseMessage Stream wrapper.
+/// Reads content of HtttpResponseMessage as Stream.
+/// When disposed itself, also disposes wrapped HttpResponseMessage.
+/// </summary>
+public class HttpResponseStream : Stream
+{
+    private readonly HttpResponseMessage _response;
+    private readonly Stream _responseStream;
+
+    private HttpResponseStream(HttpResponseMessage response, Stream responseStream)
+    {
+        _response = response;
+        _responseStream = responseStream;
+    }
+
+    /// <summary>
+    /// Non-blocking factory.
+    /// </summary>
+    /// <param name="response">HttpResponseMessage to wrap.</param>
+    /// <returns></returns>
+    public static async Task<HttpResponseStream> CreateAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
+    {
+        return new(response, await response.Content.ReadAsStreamAsync(cancellationToken));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _responseStream.Dispose();
+        _response.Dispose();
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _responseStream.DisposeAsync();
+        _response.Dispose();
+        await base.DisposeAsync();
+        
+        GC.SuppressFinalize(this);
+    }
+    
+    public override bool CanRead => _responseStream.CanRead;
+
+    public override bool CanSeek => _responseStream.CanSeek;
+
+    public override bool CanWrite => _responseStream.CanWrite;
+
+    public override long Length => _responseStream.Length;
+
+    public override long Position { get => _responseStream.Position; set => _responseStream.Position = value; }
+
+    public override void Flush() => _responseStream.Flush();
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        return _responseStream.ReadAsync(buffer, cancellationToken);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => _responseStream.Read(buffer, offset, count);
+
+    public override long Seek(long offset, SeekOrigin origin) => _responseStream.Seek(offset, origin);
+
+    public override void SetLength(long value) => _responseStream.SetLength(value);
+
+    public override void Write(byte[] buffer, int offset, int count) => _responseStream.Write(buffer, offset, count);
+}

--- a/octo-fiesta/Services/Deezer/DeezerDecryptedStream.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDecryptedStream.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+using System.Text;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
+
+namespace octo_fiesta.Services.Deezer;
+
+public sealed class DeezerDecryptedStream(Stream source, string trackId) : Stream
+{
+        
+    // Deezer's standard Blowfish CBC encryption key for track decryption
+    // This is a well-known constant used by the Deezer API, not a user-specific secret
+    private const string BfSecret = "g4el58wc0zvf9na1";
+    private static byte[] Iv { get => [0, 1, 2, 3, 4, 5, 6, 7]; }
+    private readonly Stream _source = source;
+    private readonly byte[] _bfKey = GetBlowfishKey(trackId);
+    private readonly byte[] _readBuffer = new byte[2048];
+    private byte[] _currentChunk = [];
+    private int _chunkOffset = 0;
+    private int _chunkIndex = 0;
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+    {
+        // read and optionally decrypt new chunk from input stream
+        if (_chunkOffset >= _currentChunk.Length)
+        {
+            var bytesRead = await _source.ReadAtLeastAsync(
+                _readBuffer,
+                _readBuffer.Length,
+                throwOnEndOfStream: false,
+                cancellationToken);
+            
+            if (bytesRead == 0) return 0;
+
+            _currentChunk = _readBuffer.AsSpan(0, bytesRead).ToArray();
+
+            // Every 3rd chunk (index % 3 == 0) is encrypted
+            if (_chunkIndex % 3 == 0 && bytesRead == 2048)
+            {
+                _currentChunk = DecryptBlowfishCbc(_currentChunk);
+            }
+
+            _chunkOffset = 0;
+            _chunkIndex++;
+        }
+
+        // copy (part of) current chunk into destination buffer
+        int bytesToCopy = Math.Min(destination.Length, _currentChunk.Length - _chunkOffset);
+        _currentChunk.AsSpan(_chunkOffset, bytesToCopy).CopyTo(destination.Span);
+
+        _chunkOffset += bytesToCopy;
+
+        return bytesToCopy;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        _source.Dispose();
+        base.Dispose(disposing);
+    }
+    
+    public override async ValueTask DisposeAsync()
+    {
+        await _source.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private static byte[] GetBlowfishKey(string trackId)
+    {
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(trackId));
+        var hashHex = Convert.ToHexString(hash).ToLower();
+        
+        var bfKey = new byte[16];
+        for (int i = 0; i < 16; i++)
+        {
+            bfKey[i] = (byte)(hashHex[i] ^ hashHex[i + 16] ^ BfSecret[i]);
+        }
+        
+        return bfKey;
+    }
+
+    private byte[] DecryptBlowfishCbc(byte[] data)
+    {
+        // Use BouncyCastle for native Blowfish CBC decryption
+        var engine = new BlowfishEngine();
+        var cipher = new CbcBlockCipher(engine);
+        cipher.Init(false, new ParametersWithIV(new KeyParameter(_bfKey), Iv));
+        
+        var output = new byte[data.Length];
+        var blockSize = cipher.GetBlockSize(); // 8 bytes for Blowfish
+        
+        for (int offset = 0; offset < data.Length; offset += blockSize)
+        {
+            cipher.ProcessBlock(data, offset, output, offset);
+        }
+        
+        return output;
+    }
+}

--- a/octo-fiesta/Services/Deezer/DeezerDecryptedStream.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDecryptedStream.cs
@@ -55,7 +55,7 @@ public sealed class DeezerDecryptedStream(Stream source, string trackId) : Strea
     }
 
     public override bool CanRead => true;
-    public override bool CanSeek => true;
+    public override bool CanSeek => false;
     public override bool CanWrite => false;
     public override long Length => throw new NotSupportedException();
     public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -131,7 +131,7 @@ public class DeezerDownloadService : BaseDownloadService
 
         // Decrypt
         // Streams are disposed at the calling side
-        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var responseStream = await HttpResponseStream.CreateAsync(response, cancellationToken);
         var downloadStream = new DeezerDecryptedStream(responseStream, trackId);
 
         return new DownloadResult(downloadStream, extension, downloadedQuality);

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -93,7 +93,7 @@ public class DeezerDownloadService : BaseDownloadService
     
     protected override string? GetTargetQuality() => _preferredQuality ?? "FLAC";
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         var downloadInfo = await GetTrackDownloadInfoAsync(trackId, cancellationToken);
         

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -37,10 +37,6 @@ public class DeezerDownloadService : BaseDownloadService
     private readonly int _minRequestIntervalMs = 200;
     
     private const string DeezerApiBase = "https://api.deezer.com";
-    
-    // Deezer's standard Blowfish CBC encryption key for track decryption
-    // This is a well-known constant used by the Deezer API, not a user-specific secret
-    private const string BfSecret = "g4el58wc0zvf9na1";
 
     protected override string ProviderName => "deezer";
 
@@ -120,53 +116,25 @@ public class DeezerDownloadService : BaseDownloadService
             _ => downloadInfo.Format
         };
 
-        // Build organized folder structure using configured template
-        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
-        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
-        var basePath = useCache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
-        
-        // Create directories if they don't exist
-        var albumFolder = Path.GetDirectoryName(outputPath)!;
-        EnsureDirectoryExists(albumFolder);
-        
-        // Resolve unique path if file already exists
-        outputPath = PathHelper.ResolveUniquePath(outputPath);
 
-        try
+        // Download the encrypted file
+        var response = await RetryWithBackoffAsync(async () =>
         {
-            // Download the encrypted file
-            var response = await RetryWithBackoffAsync(async () =>
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Get, downloadInfo.DownloadUrl);
-                request.Headers.Add("User-Agent", "Mozilla/5.0");
-                request.Headers.Add("Accept", "*/*");
-                
-                return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            });
-
-            response.EnsureSuccessStatusCode();
-
-            // Download and decrypt
-            await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-            await using var outputFile = IOFile.Create(outputPath);
+            using var request = new HttpRequestMessage(HttpMethod.Get, downloadInfo.DownloadUrl);
+            request.Headers.Add("User-Agent", "Mozilla/5.0");
+            request.Headers.Add("Accept", "*/*");
             
-            // Use the actual track ID from downloadInfo for decryption (may be alternative track)
-            await DecryptAndWriteStreamAsync(responseStream, outputFile, downloadInfo.TrackId, cancellationToken);
-            
-            // Close file before writing metadata
-            await outputFile.DisposeAsync();
-            
-            // Write metadata and cover art
-            await WriteMetadataAsync(outputPath, song, cancellationToken);
+            return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        });
 
-            return new DownloadResult(outputPath, downloadedQuality);
-        }
-        catch
-        {
-            TryDeleteIncompleteFile(outputPath);
-            throw;
-        }
+        response.EnsureSuccessStatusCode();
+
+        // Decrypt
+        // Streams are disposed at the calling side
+        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var downloadStream = new DeezerDecryptedStream(responseStream, trackId);
+
+        return new DownloadResult(downloadStream, extension, downloadedQuality);
     }
 
     #endregion
@@ -420,84 +388,6 @@ public class DeezerDownloadService : BaseDownloadService
                 };
             }
         });
-    }
-
-    #endregion
-
-    #region Decryption
-
-    private byte[] GetBlowfishKey(string trackId)
-    {
-        var hash = MD5.HashData(Encoding.UTF8.GetBytes(trackId));
-        var hashHex = Convert.ToHexString(hash).ToLower();
-        
-        var bfKey = new byte[16];
-        for (int i = 0; i < 16; i++)
-        {
-            bfKey[i] = (byte)(hashHex[i] ^ hashHex[i + 16] ^ BfSecret[i]);
-        }
-        
-        return bfKey;
-    }
-
-    private async Task DecryptAndWriteStreamAsync(
-        Stream input, 
-        Stream output, 
-        string trackId, 
-        CancellationToken cancellationToken)
-    {
-        var bfKey = GetBlowfishKey(trackId);
-        var iv = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
-        
-        var buffer = new byte[2048];
-        int chunkIndex = 0;
-        
-        while (true)
-        {
-            var bytesRead = await ReadExactAsync(input, buffer, cancellationToken);
-            if (bytesRead == 0) break;
-
-            var chunk = buffer.AsSpan(0, bytesRead).ToArray();
-
-            // Every 3rd chunk (index % 3 == 0) is encrypted
-            if (chunkIndex % 3 == 0 && bytesRead == 2048)
-            {
-                chunk = DecryptBlowfishCbc(chunk, bfKey, iv);
-            }
-
-            await output.WriteAsync(chunk, cancellationToken);
-            chunkIndex++;
-        }
-    }
-
-    private async Task<int> ReadExactAsync(Stream stream, byte[] buffer, CancellationToken cancellationToken)
-    {
-        int totalRead = 0;
-        while (totalRead < buffer.Length)
-        {
-            var bytesRead = await stream.ReadAsync(buffer.AsMemory(totalRead, buffer.Length - totalRead), cancellationToken);
-            if (bytesRead == 0) break;
-            totalRead += bytesRead;
-        }
-        return totalRead;
-    }
-
-    private byte[] DecryptBlowfishCbc(byte[] data, byte[] key, byte[] iv)
-    {
-        // Use BouncyCastle for native Blowfish CBC decryption
-        var engine = new BlowfishEngine();
-        var cipher = new CbcBlockCipher(engine);
-        cipher.Init(false, new ParametersWithIV(new KeyParameter(key), iv));
-        
-        var output = new byte[data.Length];
-        var blockSize = cipher.GetBlockSize(); // 8 bytes for Blowfish
-        
-        for (int offset = 0; offset < data.Length; offset += blockSize)
-        {
-            cipher.ProcessBlock(data, offset, output, offset);
-        }
-        
-        return output;
     }
 
     #endregion

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -92,7 +92,7 @@ public class QobuzDownloadService : BaseDownloadService
     
     protected override string? GetTargetQuality() => _preferredQuality ?? "FLAC_24_HIGH";
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         // Get the download URL with signature
         var downloadInfo = await GetTrackDownloadUrlAsync(trackId, cancellationToken);

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -123,7 +123,7 @@ public class QobuzDownloadService : BaseDownloadService
         var response = await _httpClient.GetAsync(downloadInfo.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var responseStream = await HttpResponseStream.CreateAsync(response, cancellationToken);
 
         return new DownloadResult(responseStream, extension, downloadedQuality);
     }

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -120,39 +120,12 @@ public class QobuzDownloadService : BaseDownloadService
             _ => downloadInfo.MimeType?.Contains("flac") == true ? "FLAC" : "MP3_320"
         };
 
-        // Build organized folder structure using configured template
-        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
-        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
-        var basePath = useCache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
-        
-        var albumFolder = Path.GetDirectoryName(outputPath)!;
-        EnsureDirectoryExists(albumFolder);
-        
-        outputPath = PathHelper.ResolveUniquePath(outputPath);
+        var response = await _httpClient.GetAsync(downloadInfo.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
 
-        try
-        {
-            // Download the file (Qobuz files are NOT encrypted like Deezer)
-            var response = await _httpClient.GetAsync(downloadInfo.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            response.EnsureSuccessStatusCode();
+        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
 
-            await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-            await using var outputFile = IOFile.Create(outputPath);
-            
-            await responseStream.CopyToAsync(outputFile, cancellationToken);
-            await outputFile.DisposeAsync();
-            
-            // Write metadata and cover art
-            await WriteMetadataAsync(outputPath, song, cancellationToken);
-
-            return new DownloadResult(outputPath, downloadedQuality);
-        }
-        catch
-        {
-            TryDeleteIncompleteFile(outputPath);
-            throw;
-        }
+        return new DownloadResult(responseStream, extension, downloadedQuality);
     }
 
     #endregion

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -110,15 +110,15 @@ public class SquidWTFDownloadService : BaseDownloadService
         return IsQobuzSource ? "27" : "HI_RES_LOSSLESS";
     }
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         if (IsQobuzSource)
         {
-            return await DownloadTrackQobuzAsync(trackId, song, forcePermanent, cancellationToken);
+            return await DownloadTrackQobuzAsync(trackId, song, cancellationToken);
         }
         else
         {
-            return await DownloadTrackTidalAsync(trackId, song, forcePermanent, cancellationToken);
+            return await DownloadTrackTidalAsync(trackId, song, cancellationToken);
         }
     }
 
@@ -126,7 +126,7 @@ public class SquidWTFDownloadService : BaseDownloadService
 
     #region Qobuz Download
 
-    private async Task<DownloadResult> DownloadTrackQobuzAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    private async Task<DownloadResult> DownloadTrackQobuzAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         // Get download URL
         var quality = GetQobuzQuality();
@@ -190,7 +190,7 @@ public class SquidWTFDownloadService : BaseDownloadService
 
     #region Tidal Download
 
-    private async Task<DownloadResult> DownloadTrackTidalAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    private async Task<DownloadResult> DownloadTrackTidalAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         var requestedQuality = GetTidalQuality();
         var (manifest, actualQuality) = await GetTidalManifestAsync(trackId, requestedQuality, cancellationToken);

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -148,7 +148,8 @@ public class SquidWTFDownloadService : BaseDownloadService
         
         var downloadUrl = downloadResponse.Data.Url;
         Logger.LogInformation("Got download URL for track {TrackId}: {Title}", trackId, song.Title);
-        
+
+        Stream downloadStream = await GetDownloadStreamAsync(downloadUrl, cancellationToken);        
         // Determine file extension based on quality
         // Qobuz: 27/7/6 = FLAC, 5 = MP3
         var extension = quality == "5" ? ".mp3" : ".flac";
@@ -160,35 +161,8 @@ public class SquidWTFDownloadService : BaseDownloadService
             "5" => "MP3_320",
             _ => "FLAC"
         };
-        
-        // Build output path
-        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
-        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
-        var basePath = useCache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
-        
-        // Create directories
-        var albumFolder = Path.GetDirectoryName(outputPath)!;
-        EnsureDirectoryExists(albumFolder);
-        
-        // Resolve unique path if file already exists
-        outputPath = PathHelper.ResolveUniquePath(outputPath);
-        
-        try
-        {
-            // Download the file (no decryption needed)
-            await DownloadFileAsync(downloadUrl, outputPath, cancellationToken);
-            
-            // Write metadata
-            await WriteMetadataAsync(outputPath, song, cancellationToken);
-            
-            return new DownloadResult(outputPath, downloadedQuality);
-        }
-        catch
-        {
-            TryDeleteIncompleteFile(outputPath);
-            throw;
-        }
+
+        return new DownloadResult(downloadStream, extension, downloadedQuality);
     }
 
     private string GetQobuzQuality()
@@ -228,39 +202,12 @@ public class SquidWTFDownloadService : BaseDownloadService
         
         var downloadUrl = manifest.Urls[0];
         Logger.LogInformation("Got download URL for track {TrackId}: {Title} (quality: {Quality})", trackId, song.Title, actualQuality);
-        
-        // Determine file extension based on manifest mime type
+
+        Stream downloadStream = await GetDownloadStreamAsync(downloadUrl, cancellationToken);        
         var extension = GetExtensionFromMimeType(manifest.MimeType);
         var downloadedQuality = GetDownloadedQuality(actualQuality, manifest.MimeType);
         
-        // Build output path
-        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
-        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
-        var basePath = useCache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
-        
-        // Create directories
-        var albumFolder = Path.GetDirectoryName(outputPath)!;
-        EnsureDirectoryExists(albumFolder);
-        
-        // Resolve unique path if file already exists
-        outputPath = PathHelper.ResolveUniquePath(outputPath);
-        
-        try
-        {
-            // Download the file (no decryption needed)
-            await DownloadFileAsync(downloadUrl, outputPath, cancellationToken);
-            
-            // Write metadata
-            await WriteMetadataAsync(outputPath, song, cancellationToken);
-            
-            return new DownloadResult(outputPath, downloadedQuality);
-        }
-        catch
-        {
-            TryDeleteIncompleteFile(outputPath);
-            throw;
-        }
+        return new DownloadResult(downloadStream, extension, downloadedQuality);
     }
 
     /// <summary>
@@ -373,7 +320,7 @@ public class SquidWTFDownloadService : BaseDownloadService
         return "MP3_320";
     }
 
-    private async Task DownloadFileAsync(string url, string outputPath, CancellationToken cancellationToken)
+    private async Task<Stream> GetDownloadStreamAsync(string url, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Add("User-Agent", "Mozilla/5.0");
@@ -382,12 +329,7 @@ public class SquidWTFDownloadService : BaseDownloadService
         var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
         
-        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        await using var outputFile = IOFile.Create(outputPath);
-        
-        await responseStream.CopyToAsync(outputFile, cancellationToken);
-        
-        Logger.LogInformation("Downloaded file to: {Path}", outputPath);
+        return await response.Content.ReadAsStreamAsync(cancellationToken);
     }
 
     #endregion

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -329,7 +329,7 @@ public class SquidWTFDownloadService : BaseDownloadService
         var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
         
-        return await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await HttpResponseStream.CreateAsync(response, cancellationToken);
     }
 
     #endregion

--- a/octo-fiesta/Services/Yandex/YandexDownloadService.cs
+++ b/octo-fiesta/Services/Yandex/YandexDownloadService.cs
@@ -232,7 +232,7 @@ public class YandexDownloadService : BaseDownloadService
             var response = await _httpClient.GetAsync(directUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                var encryptedStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                var encryptedStream = await HttpResponseStream.CreateAsync(response, cancellationToken);
 
                 // initialize decryption machinery
                 byte[] keyHex = Convert.FromHexString(downloadInfo.Key);
@@ -288,7 +288,7 @@ public class YandexDownloadService : BaseDownloadService
             return null;
         }
 
-        Stream downloadStream = await downloadResponse.Content.ReadAsStreamAsync(cancellationToken);
+        Stream downloadStream = await HttpResponseStream.CreateAsync(downloadResponse, cancellationToken);
         string extension = YandexQuality.CodecToExtension(downloadOption.Codec);
         string actualQuality = YandexQuality.FromApiParams(downloadOption.Codec, downloadOption.BitRate);
 

--- a/octo-fiesta/Services/Yandex/YandexDownloadService.cs
+++ b/octo-fiesta/Services/Yandex/YandexDownloadService.cs
@@ -143,16 +143,10 @@ public class YandexDownloadService : BaseDownloadService
             return null;
         }
 
+        string extension =  YandexQuality.CodecToExtension(downloadInfo.Codec);
         string actualQuality = YandexQuality.FromApiParams(downloadInfo!.Codec, downloadInfo.Bitrate);
 
-        return await SaveDownloadStreamToSongFileWithMetadata(
-            downloadStream,
-            song,
-            downloadInfo.Codec,
-            actualQuality,
-            forcePermanent,
-            cancellationToken
-        );
+        return new DownloadResult(downloadStream, extension, actualQuality);
     }
 
     private async Task<YandexDownloadInfo?> GetYandexDownloadInfoModernAsync(string trackId, CancellationToken cancellationToken)
@@ -284,7 +278,7 @@ public class YandexDownloadService : BaseDownloadService
         }
         
         // Start download
-        using var downloadResponse = await _httpClient.GetAsync(directUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        var downloadResponse = await _httpClient.GetAsync(directUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         if (!downloadResponse.IsSuccessStatusCode)
         {
             _logger.LogWarning(
@@ -294,15 +288,14 @@ public class YandexDownloadService : BaseDownloadService
             return null;
         }
 
+        Stream downloadStream = await downloadResponse.Content.ReadAsStreamAsync(cancellationToken);
+        string extension = YandexQuality.CodecToExtension(downloadOption.Codec);
         string actualQuality = YandexQuality.FromApiParams(downloadOption.Codec, downloadOption.BitRate);
-        
-        return await SaveDownloadStreamToSongFileWithMetadata(
-            await downloadResponse.Content.ReadAsStreamAsync(cancellationToken),
-            song,
-            downloadOption.Codec,
-            actualQuality,
-            forcePermanent,
-            cancellationToken
+
+        return new DownloadResult(
+            downloadStream,
+            extension,
+            actualQuality
         );
     }
 
@@ -384,43 +377,4 @@ public class YandexDownloadService : BaseDownloadService
 
     #endregion
 
-    #region Common methods for both APIs
-
-    private async Task<DownloadResult> SaveDownloadStreamToSongFileWithMetadata(Stream stream, Song song, string codec, string downloadedQuality, bool forcePermanent, CancellationToken cancellationToken)
-    {
-        // Construct download path
-        var extension = YandexQuality.CodecToExtension(codec);
-        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
-        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
-        var basePath = useCache ? CachePath : DownloadPath;
-        var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
-
-        // Create directories
-        var albumFolder = Path.GetDirectoryName(outputPath)!;
-        EnsureDirectoryExists(albumFolder);
-        
-        // Resolve unique path if file already exists
-        outputPath = PathHelper.ResolveUniquePath(outputPath);
-
-        try
-        {
-            // Download the file
-            await using var outputFile = File.Create(outputPath);
-            await stream.CopyToAsync(outputFile, cancellationToken);
-            await outputFile.DisposeAsync();
-            Logger.LogInformation("Downloaded file to: {Path}", outputPath);
-            
-            // Write metadata
-            await WriteMetadataAsync(outputPath, song, cancellationToken);
-
-            return new DownloadResult(outputPath, downloadedQuality);
-        }
-        catch
-        {
-            TryDeleteIncompleteFile(outputPath);
-            throw;
-        }
-    }
-
-    #endregion
 }

--- a/octo-fiesta/Services/Yandex/YandexDownloadService.cs
+++ b/octo-fiesta/Services/Yandex/YandexDownloadService.cs
@@ -84,10 +84,10 @@ public class YandexDownloadService : BaseDownloadService
         return true;
     }
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         
-        DownloadResult? downloadResult = await DownloadTrackModernAsync(trackId, song, forcePermanent, cancellationToken);
+        DownloadResult? downloadResult = await DownloadTrackModernAsync(trackId, song, cancellationToken);
         if (downloadResult is not null)
         {
             return downloadResult;
@@ -97,7 +97,7 @@ public class YandexDownloadService : BaseDownloadService
         );
 
 
-        downloadResult = await DownloadTrackLegacyAsync(trackId, song, forcePermanent, cancellationToken);
+        downloadResult = await DownloadTrackLegacyAsync(trackId, song, cancellationToken);
         if (downloadResult is not null)
         {
             return downloadResult;
@@ -122,7 +122,7 @@ public class YandexDownloadService : BaseDownloadService
 
     #region Modern Yandex API
     
-    private async Task<DownloadResult?> DownloadTrackModernAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    private async Task<DownloadResult?> DownloadTrackModernAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Downloading track {TrackId} with encrypted Yandex API", trackId);
         
@@ -259,7 +259,7 @@ public class YandexDownloadService : BaseDownloadService
 
     #region Legacy Yandex API
 
-    private async Task<DownloadResult?> DownloadTrackLegacyAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
+    private async Task<DownloadResult?> DownloadTrackLegacyAsync(string trackId, Song song, CancellationToken cancellationToken)
     {
          _logger.LogInformation("Downloading track {TrackId} with legacy Yandex API", trackId);
 


### PR DESCRIPTION
Hi!

I wanted to work on #123, but found out it's difficult for me to read through `BaseDownloadService.DownloadSongInternalAsync()` and keep understanding what is going on.

After finally (I hope) understanding it, I've noticed that some code blocks look redundant and also that some nesting can be eliminated.
Regarding that I:
- removed activeDownload.Status checks and waiting for another download/upgrade to finish. All the download work is done under SemaphoreSlim(1,1), so there is no actually concurrent downloads and we can skip these checks. This simplified DownloadLock releasing – now `DownloadLock.Release()` is only called inside of `finally` block.
- kept only one instance of DownloadInfo
- inverted few if/else conditions to reduce code nesting


While doing that (and keeping #123 in mind) I've noticed that every provider repeats the same job of creating output file paths, creating parent directories for these files and writing HTTP response streams to those files. 
That:
- looks like common logic, not responsibility of specific providers
- duplicates the same code and requires repeating same changes multiple times (example: recent incomplete-file cleanup feature required m8tec to add it to every ProviderDownloadService which almost led to a new bug)
- in case of adding new parameters to output file path creation logic it may require to pass them all the way down to the providers' internal `SaveToFileOrSomethingLikeThis`. 

To address these, I:
- moved output path creation and file saving logic to separate method `BaseDownloadService.SaveDownloadStreamToFileAsync()`
- changed `DownloadTrackAsync` to return `Stream` of song content instead of `string` containing downloaded file path
