### PR TITLE
fix(playlists): normalize track ordering for SquidWTF and Deezer

### DIFF
--- a/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
@@ -719,7 +719,7 @@ public class DeezerMetadataServiceTests
                         id = 111,
                         title = "Track 1",
                         duration = 200,
-                        track_position = 1,
+                        track_position = 11,
                         disk_number = 1,
                         artist = new
                         {
@@ -739,7 +739,7 @@ public class DeezerMetadataServiceTests
                         id = 222,
                         title = "Track 2",
                         duration = 180,
-                        track_position = 2,
+                        track_position = 42,
                         disk_number = 1,
                         artist = new
                         {
@@ -768,6 +768,8 @@ public class DeezerMetadataServiceTests
         Assert.Equal("Track 1", result[0].Title);
         Assert.Equal("Artist A", result[0].Artist);
         Assert.Equal("ext-deezer-song-111", result[0].Id);
+        Assert.Equal(1, result[0].Track);
+        Assert.Equal(2, result[1].Track);
     }
 
     [Fact]

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -619,20 +619,19 @@ public class DeezerMetadataService : IMusicMetadataService
             if (playlistElement.TryGetProperty("tracks", out var tracks) &&
                 tracks.TryGetProperty("data", out var tracksData))
             {
-                int trackIndex = 1;
                 foreach (var track in tracksData.EnumerateArray())
                 {
                     // For playlists, use the track's own artist (not a single album artist)
-                    var song = ParseDeezerTrack(track, trackIndex);
+                    var song = ParseDeezerTrack(track);
                     
                     // Override album name to be the playlist name
                     song.Album = playlistName;
                     
                     if (ShouldIncludeSong(song))
                     {
+                        song.Track = songs.Count + 1;
                         songs.Add(song);
                     }
-                    trackIndex++;
                 }
             }
             

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -714,6 +714,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
                     var song = MapTidalTrackToSong(item.Item);
                     if (ShouldIncludeSong(song))
                     {
+                        song.Track = songs.Count + 1;
                         songs.Add(song);
                     }
                 }


### PR DESCRIPTION
- Set Song.Track from the final playlist order instead of provider album track metadata in SquidWTF and Deezer provider.
- Adjust Deezer test to test adjusted playlist ordering.

<table>
  <tr>
    <td align="center"><b>Before (Album Order)</b></td>
    <td align="center"><b>After (Playlist Order)</b></td>
  </tr>
  <tr>
    <td>
      <img width="590" src="https://github.com/user-attachments/assets/e005390a-12a7-477b-82e3-e49c684152eb" />
    </td>
    <td>
      <img width="590" src="https://github.com/user-attachments/assets/e2257db9-488f-49f6-a278-4ebde7b2ce5e" />
    </td>
  </tr>
</table>