### PR TITLE
feat: move cached songs to permanent storage on star

### DIFF
--- a/octo-fiesta.Tests/BaseDownloadServiceCleanupTests.cs
+++ b/octo-fiesta.Tests/BaseDownloadServiceCleanupTests.cs
@@ -100,7 +100,7 @@ public class BaseDownloadServiceCleanupTests : IDisposable
 
         protected override string? GetTargetQuality() => null;
 
-        protected override Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+        protected override Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
         {
             LastOutputPath = Path.Combine(_testDownloadPath, "partial-file.mp3");
             File.WriteAllText(LastOutputPath, "partial");

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -747,6 +747,7 @@ public class SubsonicController : ControllerBase
 
     /// <summary>
     /// Stars (favorites) an item. For external playlists and albums, this triggers a full download.
+    /// In Cache mode, starring an external song moves it from cache to permanent storage.
     /// External song IDs are resolved to local Subsonic IDs when possible.
     /// </summary>
     [HttpGet, HttpPost]
@@ -768,12 +769,15 @@ public class SubsonicController : ControllerBase
             
             _logger.LogInformation("Starring external playlist {PlaylistId}, triggering download", playlistId);
             
+            // In Cache mode, download directly to permanent storage
+            var forcePermanent = _subsonicSettings.StorageMode == StorageMode.Cache;
+            
             // Trigger playlist download in background
             _ = Task.Run(async () =>
             {
                 try
                 {
-                    await _playlistSyncService.DownloadFullPlaylistAsync(playlistId);
+                    await _playlistSyncService.DownloadFullPlaylistAsync(playlistId, forcePermanent);
                 }
                 catch (Exception ex)
                 {
@@ -789,10 +793,44 @@ public class SubsonicController : ControllerBase
         if (isExternalAlbum)
         {
             _logger.LogInformation("Starring external album {AlbumId}, triggering full download", rawAlbumId);
-            _downloadService.DownloadFullAlbumInBackground(albumProvider!, albumExternalId!);
+            // In Cache mode, download directly to permanent storage
+            if (_subsonicSettings.StorageMode == StorageMode.Cache)
+            {
+                _downloadService.DownloadFullAlbumInBackgroundToPermanent(albumProvider!, albumExternalId!);
+            }
+            else
+            {
+                _downloadService.DownloadFullAlbumInBackground(albumProvider!, albumExternalId!);
+            }
             return _responseBuilder.CreateResponse(format, "starred", new { });
         }
 
+        // Check if this is an external song in Cache mode
+        if (_subsonicSettings.StorageMode == StorageMode.Cache && parameters.TryGetValue("id", out var id))
+        {
+            var (isExternal, provider, type, externalId) = _localLibraryService.ParseExternalId(id);
+            if (isExternal && string.Equals(type, "song", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(provider) && !string.IsNullOrEmpty(externalId))
+            {
+                _logger.LogInformation("Starring external song in Cache mode: {Provider}:{ExternalId}", provider, externalId);
+                
+                var permanentized = await _downloadService.PermanentizeCachedSongAsync(provider, externalId);
+                if (permanentized)
+                {
+                    _logger.LogInformation("Successfully permanentized cached song {Provider}:{ExternalId}", provider, externalId);
+                    // Return success - the song will be available locally after Navidrome scans
+                    return _responseBuilder.CreateResponse(format, "starred", new { });
+                }
+                else
+                {
+                    // Song not in cache - user needs to play it first
+                    return _responseBuilder.CreateError(format, 70, 
+                        "Song is not in cache yet. Play it first, then star it to save permanently.");
+                }
+            }
+        }
+
+        // In Permanent mode, resolve external song IDs to local Subsonic IDs
         var starResolution = await ResolveExternalSongIdIfPossible(parameters, "star");
         if (starResolution is { IsExternalSong: true, Resolved: false })
         {
@@ -800,7 +838,7 @@ public class SubsonicController : ControllerBase
                 "External song could not be starred because it is not available locally yet.");
         }
         
-        // For non-playlist items, relay to real Subsonic server
+        // For non-external items or Permanent mode, relay to real Subsonic server
         try
         {
             var result = await _proxyService.RelayAsync("rest/star", parameters);

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -98,13 +98,19 @@ public abstract class BaseDownloadService : IDownloadService
 
     public async Task<string> DownloadSongAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default)
     {
-        return await DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload: true, cancellationToken);
+        return await DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload: true, forcePermanent: false, cancellationToken);
+    }
+
+    public async Task<string> DownloadSongToPermanentAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default)
+    {
+        return await DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload: true, forcePermanent: true, cancellationToken);
     }
 
     public async Task<Stream> DownloadAndStreamAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default)
     {
-        var localPath = await DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload: true, cancellationToken);
-        return IOFile.OpenRead(localPath);
+        var localPath = await DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload: true, forcePermanent: false, cancellationToken);
+        // FileShare.Delete allows move/rename operations while the file is being streamed (required for cache-to-permanent on star)
+        return new FileStream(localPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
     }
 
     public DownloadInfo? GetDownloadStatus(string songId)
@@ -162,6 +168,20 @@ public abstract class BaseDownloadService : IDownloadService
 
     public void DownloadFullAlbumInBackground(string externalProvider, string albumExternalId)
     {
+        DownloadFullAlbumInBackgroundInternal(externalProvider, albumExternalId, forcePermanent: false);
+    }
+
+    /// <summary>
+    /// Downloads all tracks from an album in background, forcing permanent storage even in Cache mode.
+    /// Used when starring an album in Cache mode.
+    /// </summary>
+    public void DownloadFullAlbumInBackgroundToPermanent(string externalProvider, string albumExternalId)
+    {
+        DownloadFullAlbumInBackgroundInternal(externalProvider, albumExternalId, forcePermanent: true);
+    }
+
+    private void DownloadFullAlbumInBackgroundInternal(string externalProvider, string albumExternalId, bool forcePermanent)
+    {
         if (externalProvider != ProviderName)
         {
             Logger.LogWarning("Provider '{Provider}' is not supported for album download", externalProvider);
@@ -172,13 +192,130 @@ public abstract class BaseDownloadService : IDownloadService
         {
             try
             {
-                await DownloadFullAlbumAsync(albumExternalId);
+                await DownloadFullAlbumAsync(albumExternalId, forcePermanent);
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Failed to download full album {AlbumId}", albumExternalId);
             }
         });
+    }
+
+    /// <summary>
+    /// Moves a cached song to permanent storage. Used when starring a song in Cache mode.
+    /// If the song is not in cache, returns false (caller should handle this case).
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, qobuz, etc.)</param>
+    /// <param name="externalId">The external track ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if the song was moved to permanent storage, false if not found in cache</returns>
+    public async Task<bool> PermanentizeCachedSongAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default)
+    {
+        if (externalProvider != ProviderName)
+        {
+            return false;
+        }
+
+        var cachedPath = await GetCachedFilePathAsync(externalProvider, externalId, cancellationToken);
+        if (cachedPath == null || !IOFile.Exists(cachedPath))
+        {
+            Logger.LogDebug("Song not found in cache for permanentization: {Provider}:{ExternalId}", externalProvider, externalId);
+            return false;
+        }
+
+        Logger.LogInformation("Permanentizing cached song: {Provider}:{ExternalId} from {CachedPath}", externalProvider, externalId, cachedPath);
+
+        // Get song metadata (with correct AlbumArtist)
+        Song? song = null;
+        var tempSong = await MetadataService.GetSongAsync(externalProvider, externalId);
+        if (tempSong != null && !string.IsNullOrEmpty(tempSong.AlbumId) && !PlaylistIdHelper.IsExternalPlaylist(tempSong.AlbumId))
+        {
+            var albumExternalId = ExtractExternalIdFromAlbumId(tempSong.AlbumId);
+            if (!string.IsNullOrEmpty(albumExternalId))
+            {
+                var album = await MetadataService.GetAlbumAsync(externalProvider, albumExternalId);
+                if (album != null)
+                {
+                    song = album.Songs.FirstOrDefault(s => s.ExternalId == externalId);
+                    if (song == null && !string.IsNullOrEmpty(album.Artist))
+                    {
+                        tempSong.AlbumArtist = album.Artist;
+                    }
+                }
+            }
+        }
+        song ??= tempSong;
+
+        if (song == null)
+        {
+            Logger.LogWarning("Could not retrieve metadata for permanentization: {Provider}:{ExternalId}", externalProvider, externalId);
+            return false;
+        }
+
+        // Determine quality from file extension (best effort since we don't have it stored)
+        var extension = Path.GetExtension(cachedPath);
+        var downloadedQuality = extension.ToLowerInvariant() switch
+        {
+            ".flac" => "FLAC",
+            ".mp3" => "MP3",
+            _ => null
+        };
+
+        // Build permanent path
+        var permanentPath = PathHelper.BuildTrackPath(
+            DownloadPath,
+            song,
+            extension,
+            SubsonicSettings.FolderTemplate,
+            downloadedQuality);
+
+        // Create directory structure
+        var permanentDir = Path.GetDirectoryName(permanentPath);
+        if (!string.IsNullOrEmpty(permanentDir) && !Directory.Exists(permanentDir))
+        {
+            Directory.CreateDirectory(permanentDir);
+        }
+
+        // Move file (atomic on same filesystem, copy+delete on cross-filesystem)
+        try
+        {
+            IOFile.Move(cachedPath, permanentPath);
+            Logger.LogInformation("Moved cached song to permanent storage: {PermanentPath}", permanentPath);
+        }
+        catch (IOException) when (IOFile.Exists(permanentPath))
+        {
+            // File already exists at destination (maybe from a previous download)
+            Logger.LogInformation("File already exists at permanent path, removing cached copy: {PermanentPath}", permanentPath);
+            IOFile.Delete(cachedPath);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to move cached song to permanent storage: {CachedPath} -> {PermanentPath}", cachedPath, permanentPath);
+            return false;
+        }
+
+        // Invalidate the metadata path cache
+        var cacheKey = $"{externalProvider}|{externalId}";
+        _metadataPathCache.TryRemove(cacheKey, out _);
+
+        // Register in mappings
+        song.LocalPath = permanentPath;
+        await LocalLibraryService.RegisterDownloadedSongAsync(song, permanentPath, downloadedQuality);
+
+        // Trigger library scan
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await LocalLibraryService.TriggerLibraryScanAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to trigger library scan after permanentization");
+            }
+        });
+
+        return true;
     }
 
     #endregion
@@ -196,9 +333,10 @@ public abstract class BaseDownloadService : IDownloadService
     /// </summary>
     /// <param name="trackId">External track ID</param>
     /// <param name="song">Song metadata</param>
+    /// <param name="forcePermanent">If true, downloads to permanent storage even in Cache mode</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Download result with local file path and quality</returns>
-    protected abstract Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken);
+    protected abstract Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken);
 
     /// <summary>
     /// Extracts the external album ID from the internal album ID format.
@@ -219,7 +357,12 @@ public abstract class BaseDownloadService : IDownloadService
     /// <summary>
     /// Internal method for downloading a song with control over album download triggering
     /// </summary>
-    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId, bool triggerAlbumDownload, CancellationToken cancellationToken = default)
+    /// <param name="externalProvider">The external provider name</param>
+    /// <param name="externalId">The external track ID</param>
+    /// <param name="triggerAlbumDownload">Whether to trigger album download in Album mode</param>
+    /// <param name="forcePermanent">If true, downloads to permanent storage even in Cache mode (used for star album/playlist)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId, bool triggerAlbumDownload, bool forcePermanent = false, CancellationToken cancellationToken = default)
     {
         if (externalProvider != ProviderName)
         {
@@ -227,7 +370,8 @@ public abstract class BaseDownloadService : IDownloadService
         }
 
         var songId = $"ext-{externalProvider}-{externalId}";
-        var isCache = SubsonicSettings.StorageMode == StorageMode.Cache;
+        // In Cache mode, downloads go to cache unless forcePermanent is set (used by star album/playlist)
+        var isCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
 
         // Acquire lock BEFORE checking existence to prevent race conditions with concurrent requests
         await DownloadLock.WaitAsync(cancellationToken);
@@ -395,7 +539,7 @@ public abstract class BaseDownloadService : IDownloadService
                 ActiveDownloads[songId] = downloadInfo;
             }
 
-            var downloadResult = await DownloadTrackAsync(externalId, song, cancellationToken);
+            var downloadResult = await DownloadTrackAsync(externalId, song, forcePermanent, cancellationToken);
             var localPath = downloadResult.LocalPath;
 
             downloadInfo.Status = DownloadStatus.Completed;
@@ -520,15 +664,15 @@ public abstract class BaseDownloadService : IDownloadService
 
     protected async Task DownloadRemainingAlbumTracksAsync(string albumExternalId, string excludeTrackExternalId, CancellationToken cancellationToken = default)
     {
-        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId, cancellationToken);
+        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId, forcePermanent: false, cancellationToken);
     }
 
-    protected async Task DownloadFullAlbumAsync(string albumExternalId, CancellationToken cancellationToken = default)
+    protected async Task DownloadFullAlbumAsync(string albumExternalId, bool forcePermanent = false, CancellationToken cancellationToken = default)
     {
-        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId: null, cancellationToken);
+        await DownloadAlbumTracksAsync(albumExternalId, excludeTrackExternalId: null, forcePermanent, cancellationToken);
     }
 
-    private async Task DownloadAlbumTracksAsync(string albumExternalId, string? excludeTrackExternalId, CancellationToken cancellationToken = default)
+    private async Task DownloadAlbumTracksAsync(string albumExternalId, string? excludeTrackExternalId, bool forcePermanent = false, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(excludeTrackExternalId))
         {
@@ -583,7 +727,7 @@ public abstract class BaseDownloadService : IDownloadService
                 }
 
                 Logger.LogInformation("Downloading track '{Title}' from album '{Album}'", track.Title, album.Title);
-                await DownloadSongInternalAsync(ProviderName, track.ExternalId!, triggerAlbumDownload: false, cancellationToken);
+                await DownloadSongInternalAsync(ProviderName, track.ExternalId!, triggerAlbumDownload: false, forcePermanent, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -97,7 +97,7 @@ public class DeezerDownloadService : BaseDownloadService
     
     protected override string? GetTargetQuality() => _preferredQuality ?? "FLAC";
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         var downloadInfo = await GetTrackDownloadInfoAsync(trackId, cancellationToken);
         
@@ -121,7 +121,9 @@ public class DeezerDownloadService : BaseDownloadService
         };
 
         // Build organized folder structure using configured template
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
+        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
+        var basePath = useCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories if they don't exist

--- a/octo-fiesta/Services/IDownloadService.cs
+++ b/octo-fiesta/Services/IDownloadService.cs
@@ -19,6 +19,16 @@ public interface IDownloadService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The path to the downloaded file</returns>
     Task<string> DownloadSongAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads a song from an external provider, forcing permanent storage even in Cache mode.
+    /// Used when starring playlists in Cache mode.
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, qobuz, etc.)</param>
+    /// <param name="externalId">The ID on the external provider</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The path to the downloaded file</returns>
+    Task<string> DownloadSongToPermanentAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Downloads a song and streams the result progressively
@@ -43,6 +53,14 @@ public interface IDownloadService
     /// <param name="externalProvider">The provider (deezer, spotify)</param>
     /// <param name="albumExternalId">The album ID on the external provider</param>
     void DownloadFullAlbumInBackground(string externalProvider, string albumExternalId);
+
+    /// <summary>
+    /// Downloads all tracks from an album in background, forcing permanent storage even in Cache mode.
+    /// Used when starring an album in Cache mode.
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, qobuz, etc.)</param>
+    /// <param name="albumExternalId">The album ID on the external provider</param>
+    void DownloadFullAlbumInBackgroundToPermanent(string externalProvider, string albumExternalId);
     
     /// <summary>
     /// Checks if a song is currently being downloaded
@@ -57,6 +75,15 @@ public interface IDownloadService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The local file path if exists, null otherwise</returns>
     Task<string?> GetLocalPathIfExistsAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves a cached song to permanent storage. Used when starring a song in Cache mode.
+    /// </summary>
+    /// <param name="externalProvider">The provider (deezer, qobuz, etc.)</param>
+    /// <param name="externalId">The external track ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if the song was moved to permanent storage, false if not found in cache</returns>
+    Task<bool> PermanentizeCachedSongAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Checks if the service is properly configured and functional

--- a/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzDownloadService.cs
@@ -92,7 +92,7 @@ public class QobuzDownloadService : BaseDownloadService
     
     protected override string? GetTargetQuality() => _preferredQuality ?? "FLAC_24_HIGH";
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         // Get the download URL with signature
         var downloadInfo = await GetTrackDownloadUrlAsync(trackId, cancellationToken);
@@ -121,7 +121,9 @@ public class QobuzDownloadService : BaseDownloadService
         };
 
         // Build organized folder structure using configured template
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
+        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
+        var basePath = useCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         var albumFolder = Path.GetDirectoryName(outputPath)!;

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -110,15 +110,15 @@ public class SquidWTFDownloadService : BaseDownloadService
         return IsQobuzSource ? "27" : "HI_RES_LOSSLESS";
     }
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         if (IsQobuzSource)
         {
-            return await DownloadTrackQobuzAsync(trackId, song, cancellationToken);
+            return await DownloadTrackQobuzAsync(trackId, song, forcePermanent, cancellationToken);
         }
         else
         {
-            return await DownloadTrackTidalAsync(trackId, song, cancellationToken);
+            return await DownloadTrackTidalAsync(trackId, song, forcePermanent, cancellationToken);
         }
     }
 
@@ -126,7 +126,7 @@ public class SquidWTFDownloadService : BaseDownloadService
 
     #region Qobuz Download
 
-    private async Task<DownloadResult> DownloadTrackQobuzAsync(string trackId, Song song, CancellationToken cancellationToken)
+    private async Task<DownloadResult> DownloadTrackQobuzAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         // Get download URL
         var quality = GetQobuzQuality();
@@ -162,7 +162,9 @@ public class SquidWTFDownloadService : BaseDownloadService
         };
         
         // Build output path
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
+        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
+        var basePath = useCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories
@@ -214,7 +216,7 @@ public class SquidWTFDownloadService : BaseDownloadService
 
     #region Tidal Download
 
-    private async Task<DownloadResult> DownloadTrackTidalAsync(string trackId, Song song, CancellationToken cancellationToken)
+    private async Task<DownloadResult> DownloadTrackTidalAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         var requestedQuality = GetTidalQuality();
         var (manifest, actualQuality) = await GetTidalManifestAsync(trackId, requestedQuality, cancellationToken);
@@ -232,7 +234,9 @@ public class SquidWTFDownloadService : BaseDownloadService
         var downloadedQuality = GetDownloadedQuality(actualQuality, manifest.MimeType);
         
         // Build output path
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
+        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
+        var basePath = useCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
         
         // Create directories

--- a/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
+++ b/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
@@ -117,11 +117,14 @@ public class PlaylistSyncService
     /// Downloads all tracks from a playlist and creates an M3U file.
     /// This is triggered when a user stars a playlist.
     /// </summary>
-    public async Task DownloadFullPlaylistAsync(string playlistId, CancellationToken cancellationToken = default)
+    /// <param name="playlistId">The playlist ID</param>
+    /// <param name="forcePermanent">If true, downloads to permanent storage even in Cache mode (used when starring)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task DownloadFullPlaylistAsync(string playlistId, bool forcePermanent = false, CancellationToken cancellationToken = default)
     {
         try
         {
-            _logger.LogInformation("Starting download for playlist {PlaylistId}", playlistId);
+            _logger.LogInformation("Starting download for playlist {PlaylistId} (forcePermanent: {ForcePermanent})", playlistId, forcePermanent);
             
             // Parse playlist ID
             if (!PlaylistIdHelper.IsExternalPlaylist(playlistId))
@@ -184,7 +187,10 @@ public class PlaylistSyncService
                     AddTrackToPlaylistCache(trackId, playlistId);
                     
                     _logger.LogInformation("Downloading track '{Artist} - {Title}'", track.Artist, track.Title);
-                    var localPath = await downloadService.DownloadSongAsync(provider, track.ExternalId, cancellationToken);
+                    // Use DownloadSongToPermanentAsync in Cache mode when starring to ensure tracks go to permanent storage
+                    var localPath = forcePermanent
+                        ? await downloadService.DownloadSongToPermanentAsync(provider, track.ExternalId, cancellationToken)
+                        : await downloadService.DownloadSongAsync(provider, track.ExternalId, cancellationToken);
                     
                     downloadedTracks.Add((track, localPath));
                     _logger.LogDebug("Downloaded: {Path}", localPath);

--- a/octo-fiesta/Services/Yandex/YandexDownloadService.cs
+++ b/octo-fiesta/Services/Yandex/YandexDownloadService.cs
@@ -84,10 +84,10 @@ public class YandexDownloadService : BaseDownloadService
         return true;
     }
 
-    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    protected override async Task<DownloadResult> DownloadTrackAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         
-        DownloadResult? downloadResult = await DownloadTrackModernAsync(trackId, song, cancellationToken);
+        DownloadResult? downloadResult = await DownloadTrackModernAsync(trackId, song, forcePermanent, cancellationToken);
         if (downloadResult is not null)
         {
             return downloadResult;
@@ -97,7 +97,7 @@ public class YandexDownloadService : BaseDownloadService
         );
 
 
-        downloadResult = await DownloadTrackLegacyAsync(trackId, song, cancellationToken);
+        downloadResult = await DownloadTrackLegacyAsync(trackId, song, forcePermanent, cancellationToken);
         if (downloadResult is not null)
         {
             return downloadResult;
@@ -122,7 +122,7 @@ public class YandexDownloadService : BaseDownloadService
 
     #region Modern Yandex API
     
-    private async Task<DownloadResult?> DownloadTrackModernAsync(string trackId, Song song, CancellationToken cancellationToken)
+    private async Task<DownloadResult?> DownloadTrackModernAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Downloading track {TrackId} with encrypted Yandex API", trackId);
         
@@ -150,6 +150,7 @@ public class YandexDownloadService : BaseDownloadService
             song,
             downloadInfo.Codec,
             actualQuality,
+            forcePermanent,
             cancellationToken
         );
     }
@@ -264,7 +265,7 @@ public class YandexDownloadService : BaseDownloadService
 
     #region Legacy Yandex API
 
-    private async Task<DownloadResult?> DownloadTrackLegacyAsync(string trackId, Song song, CancellationToken cancellationToken)
+    private async Task<DownloadResult?> DownloadTrackLegacyAsync(string trackId, Song song, bool forcePermanent, CancellationToken cancellationToken)
     {
          _logger.LogInformation("Downloading track {TrackId} with legacy Yandex API", trackId);
 
@@ -300,6 +301,7 @@ public class YandexDownloadService : BaseDownloadService
             song,
             downloadOption.Codec,
             actualQuality,
+            forcePermanent,
             cancellationToken
         );
     }
@@ -384,11 +386,13 @@ public class YandexDownloadService : BaseDownloadService
 
     #region Common methods for both APIs
 
-    private async Task<DownloadResult> SaveDownloadStreamToSongFileWithMetadata(Stream stream, Song song, string codec, string downloadedQuality, CancellationToken cancellationToken)
+    private async Task<DownloadResult> SaveDownloadStreamToSongFileWithMetadata(Stream stream, Song song, string codec, string downloadedQuality, bool forcePermanent, CancellationToken cancellationToken)
     {
         // Construct download path
         var extension = YandexQuality.CodecToExtension(codec);
-        var basePath = SubsonicSettings.StorageMode == StorageMode.Cache ? CachePath : DownloadPath;
+        // Use permanent storage if forcePermanent is set, otherwise respect StorageMode
+        var useCache = SubsonicSettings.StorageMode == StorageMode.Cache && !forcePermanent;
+        var basePath = useCache ? CachePath : DownloadPath;
         var outputPath = PathHelper.BuildTrackPath(basePath, song, extension, SubsonicSettings.FolderTemplate, downloadedQuality);
 
         // Create directories


### PR DESCRIPTION
## Summary
- In Cache mode, starring a song moves it from cache to permanent storage (using `File.Move`, no double disk write)
- Starring an album/playlist downloads directly to permanent storage instead of cache
- Added `forcePermanent` parameter to `DownloadTrackAsync` across all download services

Closes #82