### PR TITLE
feat(playlists): resolve external song IDs in updatePlaylist endpoint

### DIFF
--- a/octo-fiesta.Tests/LocalLibraryServiceTests.cs
+++ b/octo-fiesta.Tests/LocalLibraryServiceTests.cs
@@ -1,4 +1,5 @@
 using octo_fiesta.Services.Local;
+using octo_fiesta.Services;
 using octo_fiesta.Models.Domain;
 using octo_fiesta.Models.Settings;
 using octo_fiesta.Models.Download;
@@ -19,6 +20,7 @@ public class LocalLibraryServiceTests : IDisposable
     private readonly string _testDownloadPath;
     private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
     private readonly Mock<HttpMessageHandler> _mockHandler;
+    private readonly Mock<IMusicMetadataService> _mockMetadataService;
 
     public LocalLibraryServiceTests()
     {
@@ -57,11 +59,12 @@ public class LocalLibraryServiceTests : IDisposable
         var httpClient = new HttpClient(_mockHandler.Object);
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+        _mockMetadataService = new Mock<IMusicMetadataService>();
 
         var subsonicSettings = Options.Create(new SubsonicSettings { Url = "http://localhost:4533" });
         var mockLogger = new Mock<ILogger<LocalLibraryService>>();
 
-        _service = new LocalLibraryService(configuration, _mockHttpClientFactory.Object, subsonicSettings, mockLogger.Object);
+        _service = new LocalLibraryService(configuration, _mockHttpClientFactory.Object, _mockMetadataService.Object, subsonicSettings, mockLogger.Object);
     }
 
     public void Dispose()
@@ -213,6 +216,130 @@ public class LocalLibraryServiceTests : IDisposable
         Assert.NotNull(result);
         Assert.False(result.Scanning);
         Assert.Equal(100, result.Count);
+    }
+
+    [Fact]
+    public async Task WaitForLocalIdAfterScanAsync_WhenScanCompletes_ResolvesId()
+    {
+        var song = new Song
+        {
+            Title = "Scanned Song",
+            Artist = "Scan Artist",
+            Album = "Scan Album",
+            ExternalProvider = "deezer",
+            ExternalId = "scan-id"
+        };
+        var localPath = Path.Combine(_testDownloadPath, "scan-song.mp3");
+        await File.WriteAllTextAsync(localPath, "fake audio content");
+        await _service.RegisterDownloadedSongAsync(song, localPath);
+        _service.SetSubsonicCredentials(new Dictionary<string, string>
+        {
+            ["u"] = "admin",
+            ["t"] = "token",
+            ["s"] = "salt",
+            ["v"] = "1.16.1",
+            ["c"] = "tests"
+        });
+
+        var statusCalls = 0;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("getUser"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\",\"user\":{\"adminRole\":true}}}")
+                    };
+                }
+
+                if (url.Contains("startScan"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                    };
+                }
+
+                if (url.Contains("getScanStatus"))
+                {
+                    statusCalls++;
+                    var scanning = statusCalls == 1 ? "true" : "false";
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent($"{{\"subsonic-response\":{{\"status\":\"ok\",\"scanStatus\":{{\"scanning\":{scanning},\"count\":100}}}}}}")
+                    };
+                }
+
+                if (url.Contains("search3"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"searchResult3\":{\"song\":[{\"id\":\"555\",\"title\":\"Scanned Song\",\"artist\":\"Scan Artist\",\"album\":\"Scan Album\"}]}}}")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        var result = await _service.WaitForLocalIdAfterScanAsync("deezer", "scan-id");
+
+        Assert.Equal("555", result);
+    }
+
+    [Fact]
+    public async Task GetLocalIdForExternalSongAsync_WithoutMapping_ResolvesViaMetadataAndSearch3()
+    {
+        _mockMetadataService
+            .Setup(x => x.GetSongAsync("deezer", "fallback-id"))
+            .ReturnsAsync(new Song
+            {
+                Title = "Fallback Song",
+                Artist = "Fallback Artist",
+                Album = "Fallback Album",
+                ExternalProvider = "deezer",
+                ExternalId = "fallback-id"
+            });
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("search3"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"searchResult3\":{\"song\":[{\"id\":\"777\",\"title\":\"Fallback Song\",\"artist\":\"Fallback Artist\",\"album\":\"Fallback Album\"}]}}}")
+                    };
+                }
+
+                if (url.Contains("getUser"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\",\"user\":{\"adminRole\":true}}}")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        var result = await _service.GetLocalIdForExternalSongAsync("deezer", "fallback-id");
+
+        Assert.Equal("777", result);
     }
 
     [Theory]

--- a/octo-fiesta.Tests/SubsonicControllerUpdatePlaylistTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerUpdatePlaylistTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using octo_fiesta.Controllers;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Services;
+using octo_fiesta.Services.Local;
+using octo_fiesta.Services.Subsonic;
+using System.Net;
+
+namespace octo_fiesta.Tests;
+
+public class SubsonicControllerUpdatePlaylistTests
+{
+    private readonly Mock<IMusicMetadataService> _mockMetadataService;
+    private readonly Mock<ILocalLibraryService> _mockLocalLibraryService;
+    private readonly Mock<IDownloadService> _mockDownloadService;
+    private readonly Mock<ILogger<SubsonicController>> _mockLogger;
+    private readonly SubsonicRequestParser _requestParser;
+    private readonly SubsonicResponseBuilder _responseBuilder;
+    private readonly SubsonicModelMapper _modelMapper;
+    private readonly IOptions<SubsonicSettings> _settings;
+
+    public SubsonicControllerUpdatePlaylistTests()
+    {
+        _mockMetadataService = new Mock<IMusicMetadataService>();
+        _mockLocalLibraryService = new Mock<ILocalLibraryService>();
+        _mockDownloadService = new Mock<IDownloadService>();
+        _mockLogger = new Mock<ILogger<SubsonicController>>();
+
+        _requestParser = new SubsonicRequestParser();
+        _responseBuilder = new SubsonicResponseBuilder();
+        _modelMapper = new SubsonicModelMapper(
+            _responseBuilder,
+            new Mock<ILogger<SubsonicModelMapper>>().Object);
+
+        _settings = Options.Create(new SubsonicSettings
+        {
+            Url = "http://localhost:4533"
+        });
+    }
+
+    private SubsonicController CreateController(
+        Dictionary<string, string> queryParams,
+        HttpResponseMessage proxyResponse,
+        Func<HttpRequestMessage, HttpResponseMessage>? responseFactory = null,
+        Action<HttpRequestMessage>? captureRequest = null)
+    {
+        // We can't easily mock SubsonicProxyService (concrete class with HttpClient dependency)
+        // So we create a real one with a mocked HttpClient
+        var mockHttpHandler = new Mock<HttpMessageHandler>();
+        mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captureRequest?.Invoke(req))
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) => responseFactory?.Invoke(req) ?? proxyResponse);
+
+        var httpClient = new HttpClient(mockHttpHandler.Object);
+        var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        var proxyService = new SubsonicProxyService(
+            mockHttpClientFactory.Object, _settings, httpContextAccessor);
+
+        var appLifetimeMock = new Mock<IHostApplicationLifetime>();
+        appLifetimeMock.SetupGet(x => x.ApplicationStopping).Returns(CancellationToken.None);
+
+        var controller = new SubsonicController(
+            _settings,
+            _mockMetadataService.Object,
+            _mockLocalLibraryService.Object,
+            _mockDownloadService.Object,
+            _requestParser,
+            _responseBuilder,
+            _modelMapper,
+            proxyService,
+            appLifetimeMock.Object,
+            _mockLogger.Object,
+            playlistSyncService: null);
+
+        // Set up HttpContext with query parameters
+        var httpContext = new DefaultHttpContext();
+        var queryString = string.Join("&", queryParams.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        httpContext.Request.QueryString = new QueryString("?" + queryString);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return controller;
+    }
+
+    [Fact]
+    public async Task UpdatePlaylist_WithResolvableExternalSongId_UsesLocalId()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-qobuz-song-123"))
+            .Returns((true, "qobuz", "song", "123"));
+        _mockLocalLibraryService
+            .Setup(x => x.GetLocalIdForExternalSongAsync("qobuz", "123"))
+            .ReturnsAsync("9981");
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "playlistId", "42" },
+                { "songIdToAdd", "ext-qobuz-song-123" },
+                { "f", "json" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.UpdatePlaylist();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/updatePlaylist", requestUrl);
+        Assert.Contains("songIdToAdd=9981", requestUrl);
+        Assert.DoesNotContain("ext-qobuz-song-123", requestUrl);
+
+        _mockDownloadService.Verify(
+            x => x.DownloadSongAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockLocalLibraryService.Verify(x => x.WaitForLocalIdAfterScanAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdatePlaylist_WithExternalSongId_DownloadsThenUsesResolvedLocalId()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-deezer-song-456"))
+            .Returns((true, "deezer", "song", "456"));
+        _mockLocalLibraryService
+            .SetupSequence(x => x.GetLocalIdForExternalSongAsync("deezer", "456"))
+            .ReturnsAsync((string?)null)
+            .ReturnsAsync("777");
+
+        _mockDownloadService
+            .Setup(x => x.DownloadSongAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/tmp/downloads/song.flac");
+        _mockLocalLibraryService
+            .Setup(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("777");
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "playlistId", "42" },
+                { "songIdToAdd", "ext-deezer-song-456" },
+                { "f", "json" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.UpdatePlaylist();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/updatePlaylist", requestUrl);
+        Assert.Contains("songIdToAdd=777", requestUrl);
+
+        _mockDownloadService.Verify(
+            x => x.DownloadSongAsync("deezer", "456", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockLocalLibraryService.Verify(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+}

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -873,6 +873,54 @@ public class SubsonicController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Updates a playlist. External song IDs are resolved to local Subsonic IDs.
+    /// </summary>
+    [HttpGet, HttpPost]
+    [Route("rest/updatePlaylist")]
+    [Route("rest/updatePlaylist.view")]
+    public async Task<IActionResult> UpdatePlaylist()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+
+        if (parameters.TryGetValue("songIdToAdd", out var rawSongIdToAdd) && !string.IsNullOrWhiteSpace(rawSongIdToAdd))
+        {
+            var requestedSongIds = rawSongIdToAdd
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (requestedSongIds.Length > 0)
+            {
+                var resolvedSongIds = new List<string>(requestedSongIds.Length);
+
+                foreach (var songId in requestedSongIds)
+                {
+                    var resolvedId = await ResolvePlaylistSongIdAsync(songId, HttpContext.RequestAborted);
+                    if (string.IsNullOrEmpty(resolvedId))
+                    {
+                        return _responseBuilder.CreateError(format, 70,
+                            $"Could not add external song '{songId}' to playlist: local track not available");
+                    }
+
+                    resolvedSongIds.Add(resolvedId);
+                }
+
+                parameters["songIdToAdd"] = string.Join(',', resolvedSongIds);
+            }
+        }
+
+        try
+        {
+            var result = await _proxyService.RelayAsync("rest/updatePlaylist", parameters);
+            var contentType = result.ContentType ?? $"application/{format}";
+            return File(result.Body, contentType);
+        }
+        catch (HttpRequestException ex)
+        {
+            return _responseBuilder.CreateError(format, 0, $"Error connecting to Subsonic server: {ex.Message}");
+        }
+    }
+
     private string GetExternalPlaylistIdFromStarParameters(Dictionary<string, string> parameters)
     {
         // Clients may send the playlist ID as "id" or "albumId" depending on the client
@@ -959,6 +1007,44 @@ public class SubsonicController : ControllerBase
         provider = parsedProvider;
         externalId = parsedExternalId;
         return true;
+    }
+
+    private async Task<string?> ResolvePlaylistSongIdAsync(string songId, CancellationToken cancellationToken)
+    {
+        var (isExternal, provider, type, externalId) = _localLibraryService.ParseExternalId(songId);
+
+        if (!isExternal || !string.Equals(type, "song", StringComparison.OrdinalIgnoreCase))
+        {
+            return songId;
+        }
+
+        if (string.IsNullOrEmpty(provider) || string.IsNullOrEmpty(externalId))
+        {
+            return null;
+        }
+
+        // Song already has a local Subsonic ID.
+        var localId = await _localLibraryService.GetLocalIdForExternalSongAsync(provider, externalId);
+        if (!string.IsNullOrEmpty(localId))
+        {
+            return localId;
+        }
+
+        _logger.LogInformation("Song {SongId} is not available locally yet. Downloading before playlist update.", songId);
+        await _downloadService.DownloadSongAsync(provider, externalId, cancellationToken);
+
+        localId = await _localLibraryService.WaitForLocalIdAfterScanAsync(provider, externalId, cancellationToken);
+        if (!string.IsNullOrEmpty(localId))
+        {
+            return localId;
+        }
+
+        _logger.LogWarning(
+            "Could not resolve local Subsonic ID for external song {Provider}:{ExternalId} after download and scan",
+            provider,
+            externalId);
+
+        return null;
     }
 
     // Generic endpoint to handle all subsonic API calls

--- a/octo-fiesta/Services/Local/ILocalLibraryService.cs
+++ b/octo-fiesta/Services/Local/ILocalLibraryService.cs
@@ -30,6 +30,11 @@ public interface ILocalLibraryService
     /// Gets the mapping between external ID and local ID
     /// </summary>
     Task<string?> GetLocalIdForExternalSongAsync(string externalProvider, string externalId);
+
+    /// <summary>
+    /// Triggers or waits for library indexing, then resolves the local ID.
+    /// </summary>
+    Task<string?> WaitForLocalIdAfterScanAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Parses a song ID to determine if it is external or local

--- a/octo-fiesta/Services/Local/LocalLibraryService.cs
+++ b/octo-fiesta/Services/Local/LocalLibraryService.cs
@@ -19,6 +19,7 @@ public class LocalLibraryService : ILocalLibraryService
     private readonly string _mappingFilePath;
     private readonly string _downloadDirectory;
     private readonly HttpClient _httpClient;
+    private readonly IMusicMetadataService _metadataService;
     private readonly SubsonicSettings _subsonicSettings;
     private readonly ILogger<LocalLibraryService> _logger;
     private Dictionary<string, LocalSongMapping>? _mappings;
@@ -37,12 +38,14 @@ public class LocalLibraryService : ILocalLibraryService
     public LocalLibraryService(
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
+        IMusicMetadataService metadataService,
         IOptions<SubsonicSettings> subsonicSettings,
         ILogger<LocalLibraryService> logger)
     {
         _downloadDirectory = configuration["Library:DownloadPath"] ?? Path.Combine(Directory.GetCurrentDirectory(), "downloads");
         _mappingFilePath = Path.Combine(_downloadDirectory, ".mappings.json");
         _httpClient = httpClientFactory.CreateClient();
+        _metadataService = metadataService;
         _subsonicSettings = subsonicSettings.Value;
         _logger = logger;
         
@@ -115,19 +118,43 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         var mappings = await LoadMappingsAsync();
         var key = $"{externalProvider}:{externalId}";
 
-        if (!mappings.TryGetValue(key, out var mapping) || !File.Exists(mapping.LocalPath))
+        mappings.TryGetValue(key, out var mapping);
+        if (mapping != null && !File.Exists(mapping.LocalPath))
         {
-            return null;
+            mapping = null;
         }
 
-        if (!string.IsNullOrEmpty(mapping.LocalSubsonicId))
+        if (!string.IsNullOrEmpty(mapping?.LocalSubsonicId))
         {
             return mapping.LocalSubsonicId;
         }
 
         try
         {
-            var queryText = string.Join(" ", new[] { mapping.Artist, mapping.Title }.Where(s => !string.IsNullOrWhiteSpace(s)));
+            string? title;
+            string? artist;
+            string? album;
+
+            if (mapping != null)
+            {
+                title = mapping.Title;
+                artist = mapping.Artist;
+                album = mapping.Album;
+            }
+            else
+            {
+                var externalSong = await _metadataService.GetSongAsync(externalProvider, externalId);
+                if (externalSong == null)
+                {
+                    return null;
+                }
+
+                title = externalSong.Title;
+                artist = externalSong.Artist;
+                album = externalSong.Album;
+            }
+
+            var queryText = string.Join(" ", new[] { artist, title });
             if (string.IsNullOrWhiteSpace(queryText))
             {
                 return null;
@@ -154,9 +181,9 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
                 return null;
             }
 
-            var titleKey = StringNormalizer.CreateComparisonKey(mapping.Title);
-            var artistKey = StringNormalizer.CreateComparisonKey(mapping.Artist);
-            var albumKey = StringNormalizer.CreateComparisonKey(mapping.Album);
+            var titleKey = StringNormalizer.CreateComparisonKey(title);
+            var artistKey = StringNormalizer.CreateComparisonKey(artist);
+            var albumKey = StringNormalizer.CreateComparisonKey(album);
 
             string? matchedId = null;
 
@@ -188,18 +215,21 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
                 return null;
             }
 
-            await _lock.WaitAsync();
-            try
+            if (mapping != null)
             {
-                if (mappings.TryGetValue(key, out var mappingToUpdate))
+                await _lock.WaitAsync();
+                try
                 {
-                    mappingToUpdate.LocalSubsonicId = matchedId;
-                    await SaveMappingsAsync(mappings);
+                    if (mappings.TryGetValue(key, out var mappingToUpdate))
+                    {
+                        mappingToUpdate.LocalSubsonicId = matchedId;
+                        await SaveMappingsAsync(mappings);
+                    }
                 }
-            }
-            finally
-            {
-                _lock.Release();
+                finally
+                {
+                    _lock.Release();
+                }
             }
 
             _logger.LogInformation("Resolved local Subsonic ID {LocalId} for external song {Provider}:{ExternalId}",
@@ -212,6 +242,47 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
                 externalProvider, externalId);
             return null;
         }
+    }
+
+    public async Task<string?> WaitForLocalIdAfterScanAsync(string externalProvider, string externalId, CancellationToken cancellationToken = default)
+    {
+        var localId = await GetLocalIdForExternalSongAsync(externalProvider, externalId);
+        if (!string.IsNullOrEmpty(localId))
+        {
+            return localId;
+        }
+
+        var now = DateTime.UtcNow;
+        var debounceRemaining = _scanDebounceInterval - (now - _lastScanTrigger);
+
+        var scanTriggered = await TriggerLibraryScanAsync();
+        if (!scanTriggered)
+        {
+            return await GetLocalIdForExternalSongAsync(externalProvider, externalId);
+        }
+
+        if (debounceRemaining > TimeSpan.Zero)
+        {
+            var scanStatus = await GetScanStatusAsync();
+            if (scanStatus?.Scanning != true)
+            {
+                _logger.LogInformation(
+                    "Library scan was debounced for {Provider}:{ExternalId}; waiting {DelaySeconds}s before retrying",
+                    externalProvider,
+                    externalId,
+                    Math.Ceiling(debounceRemaining.TotalSeconds));
+
+                await Task.Delay(debounceRemaining, cancellationToken);
+                scanTriggered = await TriggerLibraryScanAsync();
+                if (!scanTriggered)
+                {
+                    return await GetLocalIdForExternalSongAsync(externalProvider, externalId);
+                }
+            }
+        }
+
+        await WaitForScanToFinishAsync(cancellationToken);
+        return await GetLocalIdForExternalSongAsync(externalProvider, externalId);
     }
 
     private static IEnumerable<JsonElement> EnumerateSongs(JsonElement songNode)
@@ -467,6 +538,38 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         }
         
         return null;
+    }
+
+    private async Task WaitForScanToFinishAsync(CancellationToken cancellationToken)
+    {
+        const int pollDelayMilliseconds = 1000;
+        const int maxWaitMilliseconds = 120000;
+
+        var startedWaitingAt = DateTime.UtcNow;
+        var observedRunningScan = false;
+
+        while (DateTime.UtcNow - startedWaitingAt < TimeSpan.FromMilliseconds(maxWaitMilliseconds))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var scanStatus = await GetScanStatusAsync();
+            if (scanStatus?.Scanning == true)
+            {
+                observedRunningScan = true;
+            }
+            else if (observedRunningScan)
+            {
+                return;
+            }
+            else if (scanStatus?.Scanning == false)
+            {
+                return;
+            }
+
+            await Task.Delay(pollDelayMilliseconds, cancellationToken);
+        }
+
+        _logger.LogWarning("Timed out while waiting for library scan to finish");
     }
 }
 


### PR DESCRIPTION
- (Download &) Resolve external song IDs before proxying in updatePlayist endpoint.
- Flow: try direct local ID lookup first, then download + scan retry when track doesn't exist yet.
- Extend local ID resolution to work without an existing mapping by fetching external song metadata via search3 (prevent duplicates).
- Add WaitForLocalIdAfterScanAsync method to local library service (trigger scan, debounce handling, poll until completion, then resolve).
- Add fitting tests for updatePlaylist endpoint.