### PR TITLE
fix(docker): fix folder template variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - Subsonic__AutoUpgradeQuality=${AUTO_UPGRADE_QUALITY:-false}
       # Folder template for organizing downloaded files (default: {artist}/{album}/{track} - {title})
       # Available placeholders: {artist}, {album}, {title}, {track}, {disc}, {year}, {genre}, {quality}
-      - Subsonic__FolderTemplate=${FOLDER_TEMPLATE:-{artist}/{album}/{track} - {title}}
+      - Subsonic__FolderTemplate=${FOLDER_TEMPLATE}
       
       # ===== DEEZER SETTINGS =====
       # Deezer ARL token (required if using Deezer)


### PR DESCRIPTION
# Fix: Resolve Nested Folders and Invalid Filename Suffix in Tidal Downloads

## Problem
Downloads from Tidal backend were creating deeply nested folder structures and files with invalid `}` character suffix:

```
/app/downloads/The Beatles/Let It Be (Remastered)/06 - Let It Be/Let It Be (Remastered)/06 - Let It Be}.flac
```

Expected:
```
/app/downloads/The Beatles/Let It Be (Remastered)/06 - Let It Be.flac
```

## Root Cause
The [docker-compose.yml](cci:7://file:///C:/Users/amine/Downloads/git/octo-fiesta/docker-compose.yml:0:0-0:0) file used Docker's `${VAR:-default}` syntax with braces in the default value:

```yaml
Subsonic__FolderTemplate=${FOLDER_TEMPLATE:-{artist}/{album}/{track} - {title}}
```

Docker-compose's variable parser matches the **first `}`** it encounters (in `{artist}`) as the closing brace of the expression, causing:
- Expression: `${FOLDER_TEMPLATE:-{artist}`
- Literal text appended: `/{album}/{track} - {title}}`

Result: Template gets **doubled** with an extra `}` character, creating the nested folder structure and invalid filename suffix.

## Solution

### 1. Fix docker-compose.yml
Remove the inline default value since the app already has a proper default in code:

```yaml
# Before
- Subsonic__FolderTemplate=${FOLDER_TEMPLATE:-{artist}/{album}/{track} - {title}}

# After
- Subsonic__FolderTemplate=${FOLDER_TEMPLATE}
```

The default `{artist}/{album}/{track} - {title}` is defined in `SubsonicSettings.FolderTemplate` (C#), so no default is needed in docker-compose.

e correct path structure without nested folders or invalid characters.