### PR TITLE
fix(subsonic): preserve request body in proxy

### DIFF
--- a/octo-fiesta/Services/Subsonic/SubsonicProxyService.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicProxyService.cs
@@ -97,27 +97,27 @@ public class SubsonicProxyService
         // Forward body for POST/PUT/PATCH
         if (incomingRequest.Method != "GET" && incomingRequest.Method != "HEAD")
         {
-            // Reset position to read the buffered body from the beginning
+            // Reset position to forward the original buffered body from the beginning.
             if (incomingRequest.Body.CanSeek)
             {
                 incomingRequest.Body.Position = 0;
             }
-            
-            string bodyContent;
-            using (var reader = new StreamReader(incomingRequest.Body, leaveOpen: true))
+
+            if (incomingRequest.ContentLength is > 0 ||
+                !string.IsNullOrEmpty(incomingRequest.ContentType))
             {
-                bodyContent = await reader.ReadToEndAsync(cancellationToken);
-            }
-            
-            if (!string.IsNullOrEmpty(bodyContent))
-            {
-                request.Content = new StringContent(bodyContent);
-                
+                request.Content = new StreamContent(incomingRequest.Body);
+
                 // Preserve content type
                 if (incomingRequest.ContentType != null)
                 {
                     request.Content.Headers.ContentType = 
                         System.Net.Http.Headers.MediaTypeHeaderValue.Parse(incomingRequest.ContentType);
+                }
+
+                if (incomingRequest.ContentLength.HasValue)
+                {
+                    request.Content.Headers.ContentLength = incomingRequest.ContentLength.Value;
                 }
             }
         }

--- a/octo-fiesta/Services/Subsonic/SubsonicRequestParser.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicRequestParser.cs
@@ -80,8 +80,19 @@ public class SubsonicRequestParser
     /// </summary>
     private async Task ExtractJsonParametersAsync(HttpRequest request, Dictionary<string, string> parameters)
     {
-        using var reader = new StreamReader(request.Body);
+        // Keep the request body stream open for downstream proxy forwarding.
+        request.EnableBuffering();
+        if (request.Body.CanSeek)
+        {
+            request.Body.Position = 0;
+        }
+
+        using var reader = new StreamReader(request.Body, leaveOpen: true);
         var body = await reader.ReadToEndAsync();
+        if (request.Body.CanSeek)
+        {
+            request.Body.Position = 0;
+        }
         
         if (!string.IsNullOrEmpty(body))
         {


### PR DESCRIPTION
These fixes make it possible to use Navidrome API for login and multipart uploads:
- SubsonicProxyService.RelayRequestAsync: Replace StringContent with StreamContent to preserve binary payloads and multipart boundaries.
- SubsonicRequestParser.ExtractJsonParametersAsync: Keep request.Body stream open and reset position for downstream proxy forwarding.

Without this fix, it is not possible to upload playlist artwork through octo-fiesta proxy.
Downstream: https://github.com/m8tec/octo-sync/pull/18

Let me know if there are any concerns.