### PR TITLE
fix: sort merged album tracks first by disc, then track

### DIFF
--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -513,8 +513,11 @@ public class SubsonicController : ControllerBase
             }
 
             mergedSongs = mergedSongs
-                .OrderBy(s => s is Dictionary<string, object> dict && dict.TryGetValue("track", out var track) 
-                    ? Convert.ToInt32(track) 
+                .OrderBy(s => s is Dictionary<string, object> dict && dict.TryGetValue("discNumber", out var discNumber)
+                    ? Convert.ToInt32(discNumber)
+                    : 0)
+                .ThenBy(s => s is Dictionary<string, object> dict && dict.TryGetValue("track", out var track)
+                    ? Convert.ToInt32(track)
                     : 0)
                 .ToList();
 


### PR DESCRIPTION
Sort merged album tracks by disc number first and track number second.

This keeps tracks in multi-disc albums in the correct order after merging local and external tracks.

Fixes #191