### PR TITLE
fix: ensure consistent album artist IDs

### DIFF
--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -305,10 +305,7 @@ public class SubsonicController : ControllerBase
                     {
                         album.Artist = artistName;
                     }
-                    if (string.IsNullOrEmpty(album.ArtistId))
-                    {
-                        album.ArtistId = localArtistId;
-                    }
+                    album.ArtistId = localArtistId;
                 }
             }
         }


### PR DESCRIPTION
The iOS client Arpeggi failed to display external albums on an artist's profile. This issue was fixed by overwriting the external artist ID with the local ID, since the app filters out any albums with an artist ID different from the requested one.

<table>
  <tr>
    <td align="center"><b>Before (only local albums)</b></td>
    <td align="center"><b>After (shows external albums as well)</b></td>
  </tr>
  <tr>
    <td>
      <img width="800" src="https://github.com/user-attachments/assets/28be71dd-db94-4287-8e3f-b0f33caf3b31" />
    </td>
    <td>
      <img width="800" src="https://github.com/user-attachments/assets/8d85f874-0a0b-4bd0-86a6-28aa104f0f09" />
    </td>
  </tr>
</table>