### PR TITLE
fix: filter SquidWTF Tidal duplicated songs and albums

### DIFF
--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -512,7 +512,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
 
         // Filter duplicates
         var albums = dataResponse.Data.Albums.Items
-            .DistinctBy(a => new { a.Title, a.Artist, a.NumberOfTracks, a.ReleaseDate }).ToList();
+            .DistinctBy(a => new { a.Title, a.Artist?.Name, a.NumberOfTracks, a.ReleaseDate }).ToList();
         
         return albums
             .Take(limit)
@@ -658,7 +658,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
 
         // Filter duplicates
         var albums = dataResponse.Albums.Items
-            .DistinctBy(a => new { a.Title, a.Artist, a.NumberOfTracks, a.ReleaseDate }).ToList();
+            .DistinctBy(a => new { a.Title, a.Artist?.Name, a.NumberOfTracks, a.ReleaseDate }).ToList();
         
         // Filter albums that have this artist as main artist
         return albums

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -493,6 +493,10 @@ public class SquidWTFMetadataService : IMusicMetadataService
                 songs.Add(song);
             }
         }
+
+        // Filter duplicates
+        songs = songs
+            .DistinctBy(s => new { s.Title, s.Artist, s.Album, s.Duration, s.ReleaseDate }).ToList();
         
         return songs;
     }
@@ -505,8 +509,12 @@ public class SquidWTFMetadataService : IMusicMetadataService
         
         var dataResponse = JsonSerializer.Deserialize<TidalNestedSearchResponse>(response);
         if (dataResponse?.Data?.Albums?.Items == null) return new List<Album>();
+
+        // Filter duplicates
+        var albums = dataResponse.Data.Albums.Items
+            .DistinctBy(a => new { a.Title, a.Artist, a.NumberOfTracks, a.ReleaseDate }).ToList();
         
-        return dataResponse.Data.Albums.Items
+        return albums
             .Take(limit)
             .Select(MapTidalAlbumToAlbum)
             .ToList();
@@ -647,9 +655,13 @@ public class SquidWTFMetadataService : IMusicMetadataService
         
         var dataResponse = JsonSerializer.Deserialize<TidalArtistAlbumsResponseWrapper>(response);
         if (dataResponse?.Albums?.Items == null) return new List<Album>();
+
+        // Filter duplicates
+        var albums = dataResponse.Albums.Items
+            .DistinctBy(a => new { a.Title, a.Artist, a.NumberOfTracks, a.ReleaseDate }).ToList();
         
         // Filter albums that have this artist as main artist
-        return dataResponse.Albums.Items
+        return albums
             .Select(MapTidalAlbumToAlbum)
             .ToList();
     }


### PR DESCRIPTION
As discussed in #202, we're getting duplicated songs and albums.

This PR is my approach to fix it by filtering out song duplicates by title, artist, album, duration and release date, and album duplicates by title, artist, number of tracks and release date.

Closes #202