### PR TITLE
feat: use and save release type metadata with SquidWTF Tidal & Deezer

### DIFF
--- a/octo-fiesta/Models/Domain/Album.cs
+++ b/octo-fiesta/Models/Domain/Album.cs
@@ -11,6 +11,7 @@ public class Album
     public string? ArtistId { get; set; }
     public int? Year { get; set; }
     public int? SongCount { get; set; }
+    public string? ReleaseType { get; set; }
     public string? CoverArtUrl { get; set; }
     public string? CoverArtUrlLarge { get; set; }
     public string? Genre { get; set; }

--- a/octo-fiesta/Models/Domain/Song.cs
+++ b/octo-fiesta/Models/Domain/Song.cs
@@ -100,4 +100,9 @@ public class Song
     /// 0 = Naturally clean, 1 = Explicit, 2 = Not applicable, 3 = Clean/edited version, 6/7 = Unknown
     /// </summary>
     public int? ExplicitContentLyrics { get; set; }
+
+    /// <summary>
+    /// Album release type (album, single, ep, etc.)
+    /// </summary>
+    public string? ReleaseType { get; set; }
 }

--- a/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
+++ b/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
@@ -137,7 +137,10 @@ public class TidalAlbum
     
     [JsonPropertyName("explicit")]
     public bool Explicit { get; set; }
-    
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
     [JsonPropertyName("artist")]
     public TidalArtist? Artist { get; set; }
     
@@ -382,7 +385,10 @@ public class TidalAlbumData
     
     [JsonPropertyName("copyright")]
     public string? Copyright { get; set; }
-    
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
     [JsonPropertyName("artist")]
     public TidalArtist? Artist { get; set; }
     

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -782,6 +782,9 @@ public abstract class BaseDownloadService : IDownloadService
             if (!string.IsNullOrEmpty(song.Copyright))
                 tagFile.Tag.Copyright = song.Copyright;
 
+            if (!string.IsNullOrEmpty(song.ReleaseType))
+                tagFile.Tag.MusicBrainzReleaseType = song.ReleaseType;
+
             var comments = new List<string>();
             if (!string.IsNullOrEmpty(song.Isrc))
                 comments.Add($"ISRC: {song.Isrc}");

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -238,8 +238,9 @@ public class DeezerMetadataService : IMusicMetadataService
                 song.AlbumArtist = album.Artist;
                 song.Year ??= album.Year;
                 song.Genre ??= album.Genre;
+                song.ReleaseType ??= album.ReleaseType;
                 song.TotalTracks ??= album.SongCount;
-                
+
                 if (ShouldIncludeSong(song))
                 {
                     album.Songs.Add(song);

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -512,6 +512,9 @@ public class DeezerMetadataService : IMusicMetadataService
                     genresData.GetArrayLength() > 0
                 ? genresData[0].GetProperty("name").GetString()
                 : null,
+            ReleaseType = album.TryGetProperty("record_type", out var recordType) 
+                ? recordType.GetString() 
+                : null,
             IsLocal = false,
             ExternalProvider = "deezer",
             ExternalId = externalId

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -393,6 +393,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
                 song.Year ??= album.Year;
                 song.Genre ??= album.Genre;
                 song.TotalTracks ??= album.SongCount;
+                song.ReleaseType ??= album.ReleaseType;
                 
                 // Use album cover for tracks if track doesn't have one (common for tracks from /api/get-album)
                 if (string.IsNullOrEmpty(song.CoverArtUrl))
@@ -605,6 +606,8 @@ public class SquidWTFMetadataService : IMusicMetadataService
                     song.Year ??= album.Year;
                     song.Genre ??= album.Genre;
                     song.TotalTracks ??= album.SongCount;
+                    song.ReleaseType ??= album.ReleaseType;
+                    
                     // Use album cover for tracks if track doesn't have one
                     if (string.IsNullOrEmpty(song.CoverArtUrl))
                     {
@@ -917,6 +920,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
             Year = year,
             Isrc = track.Isrc,
             Bpm = track.Bpm,
+            ReleaseType = track.Album?.Type,
             Copyright = track.Copyright,
             TotalTracks = track.Album?.NumberOfTracks,
             CoverArtUrl = GetTidalCoverUrl(track.Album?.Cover, "320x320"),
@@ -1007,6 +1011,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
             ArtistId = mainArtist != null ? $"ext-squidwtf-artist-{mainArtist.Id}" : null,
             Year = year,
             SongCount = album.NumberOfTracks,
+            ReleaseType = album.Type,
             CoverArtUrl = GetTidalCoverUrl(album.Cover, "320x320"),
             CoverArtUrlLarge = GetTidalCoverUrl(album.Cover, "1280x1280"),
             IsLocal = false,
@@ -1057,6 +1062,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
             ArtistId = mainArtist != null ? $"ext-squidwtf-artist-{mainArtist.Id}" : null,
             Year = year,
             SongCount = albumData.NumberOfTracks,
+            ReleaseType = albumData.Type,
             CoverArtUrl = GetTidalCoverUrl(albumData.Cover, "320x320"),
             CoverArtUrlLarge = GetTidalCoverUrl(albumData.Cover, "1280x1280"),
             IsLocal = false,

--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -377,7 +377,8 @@ public class SubsonicResponseBuilder
             ["year"] = album.Year ?? 0,
             ["created"] = System.DateTime.UtcNow.ToString("o"),
             ["isExternal"] = !album.IsLocal,
-            ["displayArtist"] = album.Artist ?? ""
+            ["displayArtist"] = album.Artist ?? "",
+            ["releaseTypes"] = album.ReleaseType != null ? new List<string> { album.ReleaseType } : new List<string>(),
         };
 
         // Only include coverArt if the album has a cover URL (avoids broken images)


### PR DESCRIPTION
The best fitting ID3 tag seems to be MusicBrainzReleaseType.

I could not work on SquidWTF Qobuz as the API seems to be down.
Also I don't have credentials for normal Qobuz or Yandex.

<table>
  <tr>
    <td align="center"><b>Before (only albums)</b></td>
    <td align="center"><b>After (different release types)</b></td>
  </tr>
  <tr>
    <td>
      <img width="800" src="https://github.com/user-attachments/assets/6b76f74e-c5e2-4d8a-94d4-c5f83c738e18" />
      <p>Note: the single is a local download</p>
    </td>
    <td>
      <img width="800" src="https://github.com/user-attachments/assets/05dc98f5-032a-4361-9019-326850d6ddfa" />
    </td>
  </tr>
</table>