### PR TITLE
fix(squidwtf tidal): append song version to title

### DIFF
--- a/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
+++ b/octo-fiesta/Models/SquidWTF/TidalApiResponses.cs
@@ -80,7 +80,9 @@ public class TidalTrack
     
     [JsonPropertyName("title")]
     public string? Title { get; set; }
-    
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
     [JsonPropertyName("duration")]
     public int Duration { get; set; }
     

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -583,7 +583,6 @@ public class SquidWTFMetadataService : IMusicMetadataService
         var response = await SendTidalRequestAsync($"/album/?id={albumId}");
         
         if (response == null) return null;
-        
         var albumResponse = JsonSerializer.Deserialize<TidalAlbumResponse>(response);
         var albumData = albumResponse?.Data;
         
@@ -897,11 +896,15 @@ public class SquidWTFMetadataService : IMusicMetadataService
         // Ensure main artist is first in the list
         if (artistNames.Count == 0 && !string.IsNullOrEmpty(mainArtistName))
             artistNames.Add(mainArtistName);
-        
+
+        var title = track.Title ?? "";
+        if (!string.IsNullOrEmpty(track.Version))
+            title += $" ({track.Version})";
+
         return new Song
         {
             Id = $"ext-squidwtf-song-{externalId}",
-            Title = track.Title ?? "",
+            Title = title,
             Artist = mainArtistName,
             Artists = artistNames,
             ArtistId = track.Artist != null 


### PR DESCRIPTION
Before, song versions like remixes could not be distinguished from normal version. This commit utilizes the version json property to show the missing information in the title, like it's done by SquidWTF and Tidal web.

Fixes #205

<table>
  <tr>
    <td align="center"><b>Before (no version info)</b></td>
    <td align="center"><b>After (shows version info)</b></td>
  </tr>
  <tr>
    <td>
      <img height="400" src="https://github.com/user-attachments/assets/53ed1a95-e032-4d28-910a-c20ca5617c95" />
    </td>
    <td>
      <img height="400" src="https://github.com/user-attachments/assets/59117d96-5f5f-46f3-9157-a13bec803864" />
    </td>
  </tr>
</table>