### PR TITLE
fix(playlist): permanently save external songs

### DIFF
--- a/octo-fiesta.Tests/SubsonicControllerUpdatePlaylistTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerUpdatePlaylistTests.cs
@@ -146,7 +146,7 @@ public class SubsonicControllerUpdatePlaylistTests
     }
 
     [Fact]
-    public async Task UpdatePlaylist_WithExternalSongId_DownloadsThenUsesResolvedLocalId()
+    public async Task UpdatePlaylist_WithExternalSongId_NotInCache_DownloadsToPermanent()
     {
         // Arrange
         _mockLocalLibraryService
@@ -158,7 +158,10 @@ public class SubsonicControllerUpdatePlaylistTests
             .ReturnsAsync("777");
 
         _mockDownloadService
-            .Setup(x => x.DownloadSongAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .Setup(x => x.PermanentizeCachedSongAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _mockDownloadService
+            .Setup(x => x.DownloadSongToPermanentAsync("deezer", "456", It.IsAny<CancellationToken>()))
             .ReturnsAsync("/tmp/downloads/song.flac");
         _mockLocalLibraryService
             .Setup(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()))
@@ -189,8 +192,69 @@ public class SubsonicControllerUpdatePlaylistTests
         Assert.Contains("songIdToAdd=777", requestUrl);
 
         _mockDownloadService.Verify(
-            x => x.DownloadSongAsync("deezer", "456", It.IsAny<CancellationToken>()),
+            x => x.PermanentizeCachedSongAsync("deezer", "456", It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockDownloadService.Verify(
+            x => x.DownloadSongToPermanentAsync("deezer", "456", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockDownloadService.Verify(
+            x => x.DownloadSongAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+        _mockLocalLibraryService.Verify(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePlaylist_WithExternalSongId_AlreadyInCache_PermanentizesInsteadOfDownloading()
+    {
+        // Arrange
+        _mockLocalLibraryService
+            .Setup(x => x.ParseExternalId("ext-deezer-song-456"))
+            .Returns((true, "deezer", "song", "456"));
+        _mockLocalLibraryService
+            .SetupSequence(x => x.GetLocalIdForExternalSongAsync("deezer", "456"))
+            .ReturnsAsync((string?)null)
+            .ReturnsAsync("777");
+
+        _mockDownloadService
+            .Setup(x => x.PermanentizeCachedSongAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _mockLocalLibraryService
+            .Setup(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("777");
+
+        HttpRequestMessage? capturedRequest = null;
+        var controller = CreateController(
+            queryParams: new Dictionary<string, string>
+            {
+                { "playlistId", "42" },
+                { "songIdToAdd", "ext-deezer-song-456" },
+                { "f", "json" }
+            },
+            proxyResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            },
+            captureRequest: req => capturedRequest = req);
+
+        // Act
+        var result = await controller.UpdatePlaylist();
+
+        // Assert
+        Assert.IsType<FileContentResult>(result);
+        Assert.NotNull(capturedRequest);
+        var requestUrl = capturedRequest!.RequestUri!.ToString();
+        Assert.Contains("/rest/updatePlaylist", requestUrl);
+        Assert.Contains("songIdToAdd=777", requestUrl);
+
+        _mockDownloadService.Verify(
+            x => x.PermanentizeCachedSongAsync("deezer", "456", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockDownloadService.Verify(
+            x => x.DownloadSongToPermanentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockDownloadService.Verify(
+            x => x.DownloadSongAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
         _mockLocalLibraryService.Verify(x => x.WaitForLocalIdAfterScanAsync("deezer", "456", It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -1072,7 +1072,10 @@ public class SubsonicController : ControllerBase
         }
 
         _logger.LogInformation("Song {SongId} is not available locally yet. Downloading before playlist update.", songId);
-        await _downloadService.DownloadSongAsync(provider, externalId, cancellationToken);
+        if (!await _downloadService.PermanentizeCachedSongAsync(provider, externalId, cancellationToken))
+        {
+           await _downloadService.DownloadSongToPermanentAsync(provider, externalId, cancellationToken);
+        }
 
         localId = await _localLibraryService.WaitForLocalIdAfterScanAsync(provider, externalId, cancellationToken);
         if (!string.IsNullOrEmpty(localId))


### PR DESCRIPTION
Songs will be downloaded permanentl when added to playlist

In Cache mode adding an external song to a playlist downloaded that song into the cache but failed to add it to the playlist because it was not saved in the permanent navidrome storage. With this change the song will be moved from cache to the permanent storage, if its not in the cache it will be directly downloaded into the permanent storage from the provider. This results in the effect that every song that is added to a playlist will be downloaded permanently what I think is fine because noone is adding songs to a playlist that he not wanna hear again. Aside from that it makes the wokflow a bit more fluent to just add a song to the playlist instead of starring it and then add it to a playlist.

KNOWN LIMITATIONS:
Currently this will only work if the logged in user has admin permissions in navidrome. Otherwise the song still gets downloaded permanently but not gets autoaticly added to the playlist so the user has to trigger the add to a play list manualy again.