### PR TITLE
feature/add-admin-account-support-for-server-to-server-communication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Navidrome/Subsonic server URL
 SUBSONIC_URL=http://localhost:4533
 
+# Admin username to perform actions on navidrome server that require admin permissions (optional)
+SUBSONIC_ADMIN_USERNAME=your-admin-username
+
+# Admin Password to perform actions on navidrome server that require admin permissions (optional)
+SUBSONIC_ADMIN_PASSWORD=your-admin-password
+
 # Path where downloaded songs will be stored on the host (only applies if STORAGE_MODE=Permanent)
 DOWNLOAD_PATH=./downloads
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       # ===== SUBSONIC SETTINGS =====
       # Navidrome/Subsonic server URL
       - Subsonic__Url=${SUBSONIC_URL:-http://localhost:4533}
+      # Admin username to perform actions on navidrome server that require admin permissions (optional)
+      - Subsonic__AdminUsername=${SUBSONIC_ADMIN_USERNAME:-}
+      # Admin Password to perform actions on navidrome server that require admin permissions (optional)
+      - Subsonic__AdminPassword=${SUBSONIC_ADMIN_PASSWORD:-}
       # Music service to use: Deezer, Qobuz, or SquidWTF (default: SquidWTF)
       - Subsonic__MusicService=${MUSIC_SERVICE:-SquidWTF}
       # Storage mode: Permanent (saved to library), Cache (temporary, auto-cleanup)

--- a/octo-fiesta.Tests/LocalLibraryServiceTests.cs
+++ b/octo-fiesta.Tests/LocalLibraryServiceTests.cs
@@ -756,6 +756,203 @@ public class LocalLibraryServiceTests : IDisposable
         Assert.Equal(2, updateCallCount);
     }
 
+    [Fact]
+    public async Task TriggerLibraryScanAsync_WithAdminSettings_UsesAdminCredentials()
+    {
+        // Arrange: service configured with an admin account
+        var service = BuildService(adminUsername: "configured-admin", adminPassword: "secret");
+
+        // Also set user credentials with a DIFFERENT username so we can tell which one
+        // ends up in the scan request URL.
+        service.SetSubsonicCredentials(new Dictionary<string, string>
+        {
+            ["u"] = "request-user",
+            ["t"] = "user-token",
+            ["s"] = "user-salt",
+            ["v"] = "1.16.1",
+            ["c"] = "aonsoku"
+        });
+
+        // Mock: every getUser call returns adminRole=true (regardless of whose it asks about).
+        // Capture every outgoing URL so we can inspect later which one reached startScan.
+        var capturedUris = new List<Uri?>();
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedUris.Add(req.RequestUri))
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("getUser"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\",\"user\":{\"adminRole\":true}}}")
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        // Act
+        var result = await service.TriggerLibraryScanAsync();
+
+        // Assert: scan was triggered using the admin account's username, not the request user's
+        Assert.True(result);
+        var scanUri = capturedUris.FirstOrDefault(u => u?.ToString().Contains("startScan") == true);
+        Assert.NotNull(scanUri);
+        Assert.Contains("u=configured-admin", scanUri!.Query);
+        Assert.DoesNotContain("u=request-user", scanUri.Query);
+    }
+
+    [Fact]
+    public async Task TriggerLibraryScanAsync_AdminSettingsButNotAdmin_FallsBackToUserWhenUserIsAdmin()
+    {
+        // Scenario: admin account is configured, but Navidrome currently says it is NOT admin
+        // (e.g. privileges were revoked at runtime). The request user however IS admin.
+        // Expected: resolver falls back to the user's credentials.
+        var service = BuildService(adminUsername: "configured-admin", adminPassword: "secret");
+        service.SetSubsonicCredentials(new Dictionary<string, string>
+        {
+            ["u"] = "request-user",
+            ["t"] = "user-token",
+            ["s"] = "user-salt",
+            ["v"] = "1.16.1",
+            ["c"] = "aonsoku"
+        });
+
+        // Mock: inspect the 'username' query parameter and return adminRole per identity.
+        // - configured-admin -> adminRole=false
+        // - request-user     -> adminRole=true
+        var capturedUris = new List<Uri?>();
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedUris.Add(req.RequestUri))
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("getUser"))
+                {
+                    // CheckUserIsAdminAsync always queries itself (username == authenticating user),
+                    // so the 'username' param identifies which credential set is being verified.
+                    var isAdmin = url.Contains("username=request-user");
+                    var json = $"{{\"subsonic-response\":{{\"status\":\"ok\",\"user\":{{\"adminRole\":{isAdmin.ToString().ToLower()}}}}}}}";
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        // Act
+        var result = await service.TriggerLibraryScanAsync();
+
+        // Assert: scan went out with the user's credentials since the admin account failed the check
+        Assert.True(result);
+        var scanUri = capturedUris.FirstOrDefault(u => u?.ToString().Contains("startScan") == true);
+        Assert.NotNull(scanUri);
+        Assert.Contains("u=request-user", scanUri!.Query);
+        Assert.DoesNotContain("u=configured-admin", scanUri.Query);
+    }
+
+    [Fact]
+    public async Task TriggerLibraryScanAsync_NeitherAdminCapable_NoScanTriggered()
+    {
+        // Scenario: admin account configured but is NOT admin, and the request user is ALSO not admin.
+        // Expected: no credentials with admin rights -> resolver returns null -> no scan.
+        var service = BuildService(adminUsername: "configured-admin", adminPassword: "secret");
+        service.SetSubsonicCredentials(new Dictionary<string, string>
+        {
+            ["u"] = "request-user",
+            ["t"] = "user-token",
+            ["s"] = "user-salt",
+            ["v"] = "1.16.1",
+            ["c"] = "aonsoku"
+        });
+
+        // Mock: every getUser call returns adminRole=false - nobody has admin rights.
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("getUser"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\",\"user\":{\"adminRole\":false}}}")
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        // Act
+        var result = await service.TriggerLibraryScanAsync();
+
+        // Assert: function returns false AND no startScan request was sent.
+        // (getUser calls ARE allowed - we are checking that no SCAN went out specifically.)
+        Assert.False(result);
+        _mockHandler.Protected()
+            .Verify("SendAsync", Times.Never(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("startScan")),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TriggerLibraryScanAsync_CachesUserAdminCheckAcrossCalls()
+    {
+        // Scenario: no admin account configured - resolver uses the user fallback path.
+        // After the first trigger, _userIsAdmin should be cached so subsequent triggers
+        // do not re-query getUser.
+        var service = BuildService();   // no admin settings -> user fallback path
+        service.SetSubsonicCredentials(new Dictionary<string, string>
+        {
+            ["u"] = "request-user",
+            ["t"] = "user-token",
+            ["s"] = "user-salt",
+            ["v"] = "1.16.1",
+            ["c"] = "aonsoku"
+        });
+
+        var getUserCalls = 0;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri?.ToString() ?? "";
+                if (url.Contains("getUser"))
+                {
+                    getUserCalls++;
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\",\"user\":{\"adminRole\":true}}}")
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
+                };
+            });
+
+        // Trigger twice. First call should hit getUser once; second call should NOT
+        // (the admin-status is cached in _userIsAdmin after the first check).
+        // The second call will take the debounce path for the actual scan, but that
+        // does not affect the admin-check caching we are asserting here.
+        await service.TriggerLibraryScanAsync();
+        await service.TriggerLibraryScanAsync();
+
+        Assert.Equal(1, getUserCalls);
+    }
+
     // --- Helpers ---
 
     private void SetupCredentials()
@@ -810,5 +1007,34 @@ public class LocalLibraryServiceTests : IDisposable
                     Content = new StringContent("{\"subsonic-response\":{\"status\":\"ok\"}}")
                 };
             });
+    }
+
+    private LocalLibraryService BuildService(
+        string? adminUsername = null,
+        string? adminPassword = null
+        )
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Library:DownloadPath"] = _testDownloadPath
+        })
+        .Build();
+
+        var subsonicSettings = Options.Create(new SubsonicSettings
+        {
+            Url = "https://localhost:4533",
+            AdminUsername = adminUsername,
+            AdminPassword = adminPassword
+        });
+
+        var mockLogger = new Mock<ILogger<LocalLibraryService>>();
+
+        return new LocalLibraryService(
+            configuration,
+            _mockHttpClientFactory.Object,
+            _mockMetadataService.Object,
+            subsonicSettings,
+            mockLogger.Object
+        );
     }
 }

--- a/octo-fiesta.Tests/SubsonicCredentialsTests.cs
+++ b/octo-fiesta.Tests/SubsonicCredentialsTests.cs
@@ -4,22 +4,44 @@ namespace octo_fiesta.Tests;
 
 public class SubsonicCredentialsTests
 {
-    private static Dictionary<string, string> ValidTokenAuthDictionary() => new()
+    private static Dictionary<string, string> ValidAllAuthDictionary() => new()
     {
         ["u"] = "alice",
         ["t"] = "abc123",
         ["s"] = "salt42",
+        ["p"] = "hunter2",
         ["v"] = "1.16.1",
         ["c"] = "aonsoku"
     };
 
-    private static Dictionary<string, string> ValidPasswordAuthDictionary() => new()
+    private static Dictionary<string, string> ValidTokenAuthDictionary()
     {
-        ["u"] = "alice",
-        ["p"] = "hunter2",
-        ["v"] = "1.16.1",
-        ["c"] = "feishin"
-    };
+        var dict = ValidAllAuthDictionary();
+        dict.Remove("p");
+        return dict;
+    }
+
+    private static Dictionary<string, string> ValidPasswordAuthDictionary()
+    {
+        var dict = ValidAllAuthDictionary();
+        dict.Remove("t");
+        dict.Remove("s");
+        return dict;
+    }
+
+    [Fact]
+    public void TryFromDictionary_AllParameters_KeepsAllWithoutEnrichment()
+    {
+        var result = SubsonicCredentials.TryFromDictionary(ValidAllAuthDictionary());
+
+        Assert.NotNull(result);
+        Assert.Equal("alice", result.Username);
+        Assert.Equal("abc123", result.Token);
+        Assert.Equal("salt42", result.Salt);
+        Assert.Equal("hunter2", result.Password);
+        Assert.Equal("1.16.1", result.ApiVersion);
+        Assert.Equal("aonsoku", result.ClientName);
+    }
 
     [Fact]
     public void TryFromDictionary_TokenAuth_ReturnsCredentials()
@@ -36,17 +58,20 @@ public class SubsonicCredentialsTests
     }
 
     [Fact]
-    public void TryFromDictionary_PasswordAuth_ReturnsCredentials()
+    public void TryFromDictionary_PasswordAuth_ReturnsCredentialsEnrichedWithGeneratedTokenAndSalt()
     {
         var result = SubsonicCredentials.TryFromDictionary(ValidPasswordAuthDictionary());
 
         Assert.NotNull(result);
         Assert.Equal("alice", result.Username);
         Assert.Equal("hunter2", result.Password);
-        Assert.Null(result.Token);
-        Assert.Null(result.Salt);
+        Assert.NotNull(result.Token);
+        Assert.NotNull(result.Salt);
         Assert.Equal("1.16.1", result.ApiVersion);
-        Assert.Equal("feishin", result.ClientName);
+        Assert.Equal("aonsoku", result.ClientName);
+
+        var expectedToken = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(System.Text.Encoding.UTF8.GetBytes("hunter2" + result.Salt))).ToLowerInvariant();
+        Assert.Equal(expectedToken, result.Token);
     }
 
     [Theory]
@@ -57,6 +82,34 @@ public class SubsonicCredentialsTests
     {
         var parameters = ValidTokenAuthDictionary();
         parameters.Remove(keyToRemove);
+
+        var result = SubsonicCredentials.TryFromDictionary(parameters);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("u")]
+    [InlineData("v")]
+    [InlineData("c")]
+    public void TryFromDictionary_EmptyRequiredParameter_ReturnsNull(string keyToRemove)
+    {
+        var parameters = ValidTokenAuthDictionary();
+        parameters[keyToRemove] = "";
+
+        var result = SubsonicCredentials.TryFromDictionary(parameters);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("u")]
+    [InlineData("v")]
+    [InlineData("c")]
+    public void TryFromDictionary_OnlyWhiteSpaceInRequiredParameter_ReturnsNull(string keyToRemove)
+    {
+        var parameters = ValidTokenAuthDictionary();
+        parameters[keyToRemove] = "   ";
 
         var result = SubsonicCredentials.TryFromDictionary(parameters);
 
@@ -79,7 +132,28 @@ public class SubsonicCredentialsTests
     }
 
     [Fact]
-    public void TryFromDictionary_TokenWithoutSalt_ReturnsNull()
+    public void TryFromDictionary_TokenAndPasswordWithoutSalt_ReturnsCredentialsEnrichedWithGeneratedSaltAndNewToken()
+    {
+        var parameters = ValidAllAuthDictionary();
+        parameters.Remove("s");
+
+        var result = SubsonicCredentials.TryFromDictionary(parameters);
+
+        Assert.NotNull(result);
+        Assert.Equal("alice", result.Username);
+        Assert.Equal("hunter2", result.Password);
+        Assert.NotNull(result.Token);
+        Assert.NotEqual(parameters["t"], result.Token);
+        Assert.NotNull(result.Salt);
+        Assert.Equal("1.16.1", result.ApiVersion);
+        Assert.Equal("aonsoku", result.ClientName);
+
+        var expectedToken = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(System.Text.Encoding.UTF8.GetBytes("hunter2" + result.Salt))).ToLowerInvariant();
+        Assert.Equal(expectedToken, result.Token);
+    }
+
+    [Fact]
+    public void TryFromDictionary_TokenWithoutSaltAndPassword_ReturnsNull()
     {
         var parameters = ValidTokenAuthDictionary();
         parameters.Remove("s");
@@ -88,4 +162,35 @@ public class SubsonicCredentialsTests
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public void TryFromDictionary_SaltWithoutTokenAndPassword_ReturnsNull()
+    {
+        var parameters = ValidTokenAuthDictionary();
+        parameters.Remove("t");
+
+        var result = SubsonicCredentials.TryFromDictionary(parameters);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryFromDictionary_PasswordAuth_GeneratesDifferentSaltsAcrossCalls()
+    {
+        var result1 = SubsonicCredentials.TryFromDictionary(ValidPasswordAuthDictionary());
+        var result2 = SubsonicCredentials.TryFromDictionary(ValidPasswordAuthDictionary());
+
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+        Assert.NotEqual(result1.Salt, result2.Salt);
+    }
+
+    [Fact]
+    public void TryFromDictionary_NullDict_ReturnsNull()
+    {
+        var result = SubsonicCredentials.TryFromDictionary(null);
+
+        Assert.Null(result);
+    }
 }
+

--- a/octo-fiesta/Models/Settings/SubsonicSettings.cs
+++ b/octo-fiesta/Models/Settings/SubsonicSettings.cs
@@ -86,6 +86,24 @@ public enum MusicService
 public class SubsonicSettings
 {
     public string? Url { get; set; }
+
+    /// <summary>
+    /// Admin username for server-to-server actions that require admin privileges.
+    /// Environment variable: SUBSONIC_ADMIN_USERNAME
+    /// Both admin username and password has to be set to use it.
+    /// If not set the user credentials will be used to perform server-to-server actions
+    /// (this may cause problems if the user has no admin permissions on the navidrome server)
+    /// </summary>
+    public string? AdminUsername { get; set; }
+
+    /// <summary>
+    /// Admin password for server-to-server actions that require admin privileges.
+    /// Environment variable: SUBSONIC_ADMIN_PASSWORD
+    /// Both admin username and password has to be set to use it.
+    /// If not set the user credentials will be used to perform server-to-server actions
+    /// (this may cause problems if the user has no admin permissions on the navidrome server)
+    /// </summary>
+    public string? AdminPassword { get; set; }
     
     /// <summary>
     /// Explicit content filter mode (default: All)

--- a/octo-fiesta/Models/Subsonic/Credentials.cs
+++ b/octo-fiesta/Models/Subsonic/Credentials.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace octo_fiesta.Models.Subsonic;
 
 /// <summary>
@@ -15,18 +18,42 @@ public record SubsonicCredentials(
     public static SubsonicCredentials? TryFromDictionary(IDictionary<string, string>? dict)
     {
         if (dict == null) return null;
-        if (!dict.TryGetValue("u", out var username) || string.IsNullOrEmpty(username)) return null;
-        if (!dict.TryGetValue("v", out var apiVersion) || string.IsNullOrEmpty(apiVersion)) return null;
-        if (!dict.TryGetValue("c", out var clientName) || string.IsNullOrEmpty(clientName)) return null;
+        if (!dict.TryGetValue("u", out var username) || string.IsNullOrWhiteSpace(username)) return null;
+        if (!dict.TryGetValue("v", out var apiVersion) || string.IsNullOrWhiteSpace(apiVersion)) return null;
+        if (!dict.TryGetValue("c", out var clientName) || string.IsNullOrWhiteSpace(clientName)) return null;
 
         dict.TryGetValue("t", out var token);
         dict.TryGetValue("s", out var salt);
         dict.TryGetValue("p", out var password);
 
-        var hasToken = !string.IsNullOrEmpty(token) && !string.IsNullOrEmpty(salt);
-        var hasPassword = !string.IsNullOrEmpty(password);
+        var hasToken = !string.IsNullOrWhiteSpace(token) && !string.IsNullOrWhiteSpace(salt);
+        var hasPassword = !string.IsNullOrWhiteSpace(password);
         if (!hasToken && !hasPassword) return null;
+        if (!hasToken)
+        {
+            salt = GenerateSalt();
+            token = ComputeTokenFromPassword(password!, salt);
+        }
 
         return new SubsonicCredentials(username, token, salt, password, apiVersion, clientName);
     }
+
+    private static string ComputeTokenFromPassword(
+        string password,
+        string salt
+        )
+    {
+        var bytes = MD5.HashData(Encoding.UTF8.GetBytes(password + salt));
+        var token = Convert.ToHexString(bytes).ToLowerInvariant();
+
+        return token;
+    }
+
+    private static string GenerateSalt()
+    {
+        var saltBytes = RandomNumberGenerator.GetBytes(8);
+        var salt = Convert.ToHexString(saltBytes).ToLowerInvariant();
+        return salt;
+    }
 }
+

--- a/octo-fiesta/Services/Local/LocalLibraryService.cs
+++ b/octo-fiesta/Services/Local/LocalLibraryService.cs
@@ -29,7 +29,10 @@ public class LocalLibraryService : ILocalLibraryService
     private DateTime _lastScanTrigger = DateTime.MinValue;
     private readonly TimeSpan _scanDebounceInterval = TimeSpan.FromSeconds(30);
     
-    // Stored Subsonic auth parameters for server-to-server calls
+    // Primary subsonic auth parameters/credentials from config for server-to-server calls
+    private SubsonicCredentials? _subsonicAdminCredentials;
+
+    // Secondary subsonic auth parameters/credentials for server-to-server calls
     private SubsonicCredentials? _subsonicUserCredentials;
     
     // Whether the captured user has admin rights (null = not checked yet)
@@ -48,6 +51,14 @@ public class LocalLibraryService : ILocalLibraryService
         _metadataService = metadataService;
         _subsonicSettings = subsonicSettings.Value;
         _logger = logger;
+        var adminCredentialsParameters = new Dictionary<string, string>
+        {
+            ["u"] = _subsonicSettings.AdminUsername ?? "",
+            ["p"] = _subsonicSettings.AdminPassword ?? "",
+            ["v"] = "1.16.1",
+            ["c"] = "octo-fiesta"
+        };
+        _subsonicAdminCredentials = SubsonicCredentials.TryFromDictionary(adminCredentialsParameters);
         
         if (!Directory.Exists(_downloadDirectory))
         {
@@ -406,14 +417,14 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
                 var isAdmin = adminRole.GetBoolean();
                 if (!isAdmin)
                 {
-                    _logger.LogInformation("Subsonic user '{User}' is not admin, library scan will be skipped", subsonicCredentials.Username);
+                    _logger.LogDebug("Subsonic user '{User}' has no admin rights", subsonicCredentials.Username);
                 }
                 return isAdmin;
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to check user admin rights, library scan will be skipped");
+            _logger.LogWarning(ex, "Failed to check user admin rights");
         }
         
         return false;
@@ -584,7 +595,6 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         {
             return string.Empty;
         }
-
         var parts = new List<string>
         {
             $"u={Uri.EscapeDataString(credentials.Username)}",
@@ -592,16 +602,16 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
             $"c={Uri.EscapeDataString(credentials.ClientName)}"
         };
 
-        if (!string.IsNullOrEmpty(credentials.Token) && !string.IsNullOrEmpty(credentials.Salt))
+        if (!string.IsNullOrWhiteSpace(credentials.Token) && !string.IsNullOrWhiteSpace(credentials.Salt))
         {
             parts.Add($"t={Uri.EscapeDataString(credentials.Token)}");
             parts.Add($"s={Uri.EscapeDataString(credentials.Salt)}");
         }
-        else if (!string.IsNullOrEmpty(credentials.Password))
+        else if (!string.IsNullOrWhiteSpace(credentials.Password))
         {
             parts.Add($"p={Uri.EscapeDataString(credentials.Password)}");
         }
-
+        
         return "&" + string.Join("&", parts);
     }
 
@@ -626,14 +636,11 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
 
     public async Task<bool> TriggerLibraryScanAsync()
     {
-        // Check admin rights on first call
-        if (_userIsAdmin == null)
-        {
-            _userIsAdmin = await CheckUserIsAdminAsync(_subsonicUserCredentials);
-        }
+        var requestCredentials = await ResolveAdminCapableCredentialsAsync();
         
-        if (_userIsAdmin == false)
+        if (requestCredentials == null)
         {
+            _logger.LogWarning("Can not trigger library scan due to no available admin credentials");
             return false;
         }
         
@@ -650,7 +657,7 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         
         try
         {
-            var authQuery = BuildAuthQuery(_subsonicUserCredentials);
+            var authQuery = BuildAuthQuery(requestCredentials);
             var url = $"{_subsonicSettings.Url}/rest/startScan?f=json{authQuery}";
             
             _logger.LogInformation("Triggering Subsonic library scan...");
@@ -665,7 +672,7 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
             }
             else
             {
-                _logger.LogWarning("Failed to trigger Subsonic scan: {StatusCode} - Server may require authentication", response.StatusCode);
+                _logger.LogWarning("Failed to trigger Subsonic scan: {StatusCode}", response.StatusCode);
                 return false;
             }
         }
@@ -682,7 +689,12 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         {
             // Note: This endpoint works without authentication on most Subsonic/Navidrome servers
             // when called from localhost.
-            var authQuery = BuildAuthQuery(_subsonicUserCredentials);
+            // current behavior: tries to find admin credentials otherwise tries with not admin credentials
+            var requestCredentials = await ResolveAdminCapableCredentialsAsync();
+
+            if (requestCredentials == null) requestCredentials = _subsonicUserCredentials;
+
+            var authQuery = BuildAuthQuery(requestCredentials);
             var url = $"{_subsonicSettings.Url}/rest/getScanStatus?f=json{authQuery}";
             
             var response = await _httpClient.GetAsync(url);
@@ -741,6 +753,28 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
         }
 
         _logger.LogWarning("Timed out while waiting for library scan to finish");
+    }
+
+    private async Task<SubsonicCredentials?> ResolveAdminCapableCredentialsAsync()
+    {
+        // Check admin rights on first call
+        if (_userIsAdmin == null)
+        {
+            _userIsAdmin = await CheckUserIsAdminAsync(_subsonicUserCredentials);
+        }
+
+        if (_subsonicAdminCredentials != null && await CheckUserIsAdminAsync(_subsonicAdminCredentials))
+        {
+            return _subsonicAdminCredentials;
+        }
+        else if (_subsonicUserCredentials != null && _userIsAdmin == true)
+        {
+            return _subsonicUserCredentials;
+        }
+        else
+        {
+            return null;
+        }
     }
 }
 

--- a/octo-fiesta/Services/Local/LocalLibraryService.cs
+++ b/octo-fiesta/Services/Local/LocalLibraryService.cs
@@ -32,6 +32,9 @@ public class LocalLibraryService : ILocalLibraryService
     // Primary subsonic auth parameters/credentials from config for server-to-server calls
     private SubsonicCredentials? _subsonicAdminCredentials;
 
+    // Whether the configured admin has admin rights (null = not checked yet)
+    private bool? _adminIsAdmin;
+
     // Secondary subsonic auth parameters/credentials for server-to-server calls
     private SubsonicCredentials? _subsonicUserCredentials;
     
@@ -758,12 +761,17 @@ public async Task RegisterDownloadedSongAsync(Song song, string localPath, strin
     private async Task<SubsonicCredentials?> ResolveAdminCapableCredentialsAsync()
     {
         // Check admin rights on first call
+        if (_adminIsAdmin == null)
+        {
+            _adminIsAdmin = await CheckUserIsAdminAsync(_subsonicAdminCredentials);
+        }
+
         if (_userIsAdmin == null)
         {
             _userIsAdmin = await CheckUserIsAdminAsync(_subsonicUserCredentials);
         }
 
-        if (_subsonicAdminCredentials != null && await CheckUserIsAdminAsync(_subsonicAdminCredentials))
+        if (_subsonicAdminCredentials != null && _adminIsAdmin == true)
         {
             return _subsonicAdminCredentials;
         }

--- a/octo-fiesta/Services/Validation/SubsonicStartupValidator.cs
+++ b/octo-fiesta/Services/Validation/SubsonicStartupValidator.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 using octo_fiesta.Models.Settings;
+using octo_fiesta.Models.Subsonic;
 
 namespace octo_fiesta.Services.Validation;
 
@@ -43,12 +45,14 @@ public class SubsonicStartupValidator : BaseStartupValidator
                 if (content.Contains("\"status\":\"ok\"") || content.Contains("status=\"ok\""))
                 {
                     WriteStatus("Subsonic server", "OK", ConsoleColor.Green);
+                    await ValidateAdminAccountAsync(subsonicUrl, cancellationToken);
                     return ValidationResult.Success("Subsonic server is accessible");
                 }
                 else if (content.Contains("\"status\":\"failed\"") || content.Contains("status=\"failed\""))
                 {
                     WriteStatus("Subsonic server", "REACHABLE", ConsoleColor.Yellow);
                     WriteDetail("Authentication may be required for some operations");
+                    await ValidateAdminAccountAsync(subsonicUrl, cancellationToken);
                     return ValidationResult.Success("Subsonic server is reachable");
                 }
                 else
@@ -82,6 +86,157 @@ public class SubsonicStartupValidator : BaseStartupValidator
             WriteStatus("Subsonic server", "ERROR", ConsoleColor.Red);
             WriteDetail(ex.Message);
             return ValidationResult.Failure("ERROR", ex.Message, ConsoleColor.Red);
+        }
+    }
+
+    private async Task ValidateAdminAccountAsync(
+        string subsonicUrl,
+        CancellationToken cancellationToken
+    )
+    {
+        var adminUsername = _subsonicSettings.Value.AdminUsername;
+        var adminPassword = _subsonicSettings.Value.AdminPassword;
+
+        if (string.IsNullOrWhiteSpace(adminUsername) && string.IsNullOrWhiteSpace(adminPassword))
+        {
+            WriteStatus("Admin account", "NOT CONFIGURED", ConsoleColor.DarkGray);
+            WriteDetail("Optional - set Subsonic__AdminUsername and Subsonic__AdminPassword to avoid problems with admin required actions such as library scan");
+            return;
+        }
+        else if (string.IsNullOrWhiteSpace(adminUsername))
+        {
+            WriteStatus("Admin account", "PARTIAL CONFIG", ConsoleColor.Yellow);
+            WriteDetail("Subsonic__AdminUsername is missing - To use the admin account feature Subsonic__AdminUsername and Subsonic__AdminPassword are required.");
+            return;
+        }
+        else if (string.IsNullOrWhiteSpace(adminPassword))
+        {
+            WriteStatus("Admin account", "PARTIAL CONFIG", ConsoleColor.Yellow);
+            WriteDetail("Subsonic__AdminPassword is missing - To use the admin account feature Subsonic__AdminUsername and Subsonic__AdminPassword are required.");
+            return;
+        }
+
+        var adminCredentialsParameters = new Dictionary<string, string>
+        {
+            ["u"] = adminUsername,
+            ["p"] = adminPassword,
+            ["v"] = "1.16.1",
+            ["c"] = "octo-fiesta"
+        };
+        
+        var credentials = SubsonicCredentials.TryFromDictionary(adminCredentialsParameters);
+
+        if (credentials == null)
+        {
+            WriteStatus("Admin account", "ERROR", ConsoleColor.Red);
+            WriteDetail("Failed to build credentials from admin account configuration");
+            return;
+        }
+
+        var requestUrl = $"{subsonicUrl.TrimEnd('/')}/rest/getUser?f=json"
+        + $"&u={Uri.EscapeDataString(credentials.Username)}"
+        + $"&t={Uri.EscapeDataString(credentials.Token!)}"
+        + $"&s={Uri.EscapeDataString(credentials.Salt!)}"
+        + $"&v={Uri.EscapeDataString(credentials.ApiVersion)}"
+        + $"&c={Uri.EscapeDataString(credentials.ClientName)}"
+        + $"&username={Uri.EscapeDataString(credentials.Username)}";
+
+        try
+        {
+            var response = await _httpClient.GetAsync(requestUrl, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                WriteStatus("Admin account", $"HTTP {(int)response.StatusCode}", ConsoleColor.Red);
+                return;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(content);
+            var root = doc.RootElement.GetProperty("subsonic-response");
+
+            if (root.TryGetProperty("status", out var statusObj) && statusObj.GetString() == "failed")
+            {
+                HandleSubsonicError(root, adminUsername);
+                return;
+            }
+
+            if (root.TryGetProperty("user", out var userObj) && userObj.TryGetProperty("adminRole", out var adminRoleField))
+            {
+                if (adminRoleField.GetBoolean())
+                {
+                    WriteStatus("Admin account", "OK", ConsoleColor.Green);
+                    WriteDetail($"User '{adminUsername}' authenticated with admin rights");
+                }
+                else
+                {
+                    WriteStatus("Admin account", "NOT ADMIN", ConsoleColor.Yellow);
+                    WriteDetail($"User '{adminUsername}' authenticated but has no admin rights - this may cause problems with actions that require admin permissions e.g. library scans");
+                }
+            }
+            else
+            {
+                WriteStatus("Admin account", "UNEXPECTED RESPONSE", ConsoleColor.Yellow);
+                WriteDetail("Could not find user.adminRole in response from Navidrome");
+            }
+
+        }
+        catch (TaskCanceledException)
+        {
+            WriteStatus("Admin account", "TIMEOUT", ConsoleColor.Red);
+            WriteDetail("Admin verification did not complete within 10 seconds");
+        }
+        catch (HttpRequestException ex)
+        {
+            WriteStatus("Admin account", "UNREACHABLE", ConsoleColor.Red);
+            WriteDetail(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            WriteStatus("Admin account", "ERROR", ConsoleColor.Red);
+            WriteDetail(ex.Message);
+        }
+    }
+
+    private static void HandleSubsonicError(
+        JsonElement root,
+        string username)
+    {
+        var errorCode = 0;
+        var errorMsg = "Unknown error";
+
+        if (root.TryGetProperty("error", out var errorObj))
+        {
+            if (errorObj.TryGetProperty("code", out var errorCodeField)) errorCode = errorCodeField.GetInt32();
+            if (errorObj.TryGetProperty("message", out var errorMsgField)) errorMsg = errorMsgField.GetString();
+        }
+
+        switch (errorCode)
+        {
+            case 40:
+                WriteStatus("Admin account", "AUTH FAILED", ConsoleColor.Red);
+                WriteDetail($"Navidrome rejected credentials for '{username}' (wrong username or password)");
+                break;
+
+            case 41:
+                WriteStatus("Admin account", "TOKEN AUTH UNSUPPORTED", ConsoleColor.Red);
+                WriteDetail("Server does not support token-based auth - check Navidrome version");
+                break;
+
+            case 50:
+                WriteStatus("Admin account", "NOT AUTHORIZED", ConsoleColor.Yellow);
+                WriteDetail($"User '{username}' is not authorized to query user details");
+                break;
+
+            case 70:
+                WriteStatus("Admin account", "USER NOT FOUND", ConsoleColor.Red);
+                WriteDetail($"Navidrome could not find user '{username}'");
+                break;
+
+            default:
+                WriteStatus("Admin account", "ERROR", ConsoleColor.Red);
+                WriteDetail($"Code: {errorCode}:{errorMsg}");
+                break;
         }
     }
 }

--- a/octo-fiesta/appsettings.json
+++ b/octo-fiesta/appsettings.json
@@ -10,6 +10,8 @@
   "AllowedHosts": "*",
   "Subsonic": {
     "Url": "http://localhost:4533",
+    "AdminUsername": "",
+    "AdminPassword": "",
     "ExplicitFilter": "All",
     "DownloadMode": "Track",
     "StorageMode": "Permanent",


### PR DESCRIPTION
## Summary

Adds support for a configurable admin account for server-to-server actions requiring admin privileges (currently: library scan triggers). Falls back to the request user's credentials when unset — no behavior change for single-admin setups.


## Motivation

`TriggerLibraryScanAsync` currently reuses the credentials of the first user that hits octo-fiesta. In multi-user setups, scan triggers silently fail if that first user isn't admin. This PR adds a dedicated config-driven admin account to make scan triggers reliable regardless of who connects first.


## What's new

- Two new optional settings: `Subsonic:AdminUsername` / `Subsonic:AdminPassword` (env: `SUBSONIC_ADMIN_USERNAME` / `SUBSONIC_ADMIN_PASSWORD`). Both must be set to activate the feature.
- `SubsonicStartupValidator` verifies the admin account on startup and reports status in the console box: `OK` / `NOT CONFIGURED` / `PARTIAL CONFIG` / `NOT ADMIN` / `AUTH FAILED` / `USER NOT FOUND` / `UNREACHABLE` etc.
- New `ResolveAdminCapableCredentialsAsync` on `LocalLibraryService`: prefers admin, falls back to request user (if admin), else null.
- `TriggerLibraryScanAsync` uses the resolver. `GetScanStatusAsync` unchanged (can be aligned in a follow-up).
- `SubsonicCredentials.TryFromDictionary` now enriches password-only input with generated salt + computed MD5 token, so both auth methods are always available. Validation switched to `IsNullOrWhiteSpace` for consistency.


## Tests

- New tests for `TryFromDictionary`: password-auth enrichment, mixed token+password, token-without-salt fallback via password, empty/whitespace required fields, salt variance across calls.
- All existing tests pass on top of upstream `dev`.


## Documentation

The Configuration wiki page needs these two new rows:

| Setting | `.env` variable | Description | Default |
|---|---|---|---|
| `Subsonic:AdminUsername` | `SUBSONIC_ADMIN_USERNAME` | Username of a Navidrome admin account used for server-to-server admin actions (optional). | (empty) |
| `Subsonic:AdminPassword` | `SUBSONIC_ADMIN_PASSWORD` | Password for the admin account above (optional). | (empty) |


## Compatibility

No breaking changes. Deployments that don't set the new env vars behave exactly as before. `.env.example`, `docker-compose.yml`, and `appsettings.json` are updated with the new keys.