### PR TITLE
fix: parse release_type from squidwtf qobuz

### DIFF
--- a/octo-fiesta/Models/SquidWTF/QobuzApiResponses.cs
+++ b/octo-fiesta/Models/SquidWTF/QobuzApiResponses.cs
@@ -69,7 +69,9 @@ public class QobuzAlbum
     
     [JsonPropertyName("release_date_original")]
     public string? ReleaseDateOriginal { get; set; }
-    
+    [JsonPropertyName("release_type")]
+    public string? ReleaseType { get; set; }
+
     [JsonPropertyName("duration")]
     public int Duration { get; set; }
     

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -861,6 +861,7 @@ public class SquidWTFMetadataService : IMusicMetadataService
             CoverArtUrl = album.Image?.Small ?? album.Image?.Thumbnail,
             CoverArtUrlLarge = album.Image?.Large,
             Genre = album.Genre?.Name,
+            ReleaseType = album.ReleaseType,
             IsLocal = false,
             ExternalProvider = "squidwtf",
             ExternalId = externalId


### PR DESCRIPTION
Parsing release type worked for squidwtf Tidal but not for Qobuz