### PR TITLE
fix(deezer): fetch all album tracks via paginated tracklist endpoint

### DIFF
--- a/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
@@ -234,6 +234,112 @@ public class DeezerMetadataServiceTests
             release_date = "2023-05-20",
             cover_medium = "https://example.com/album.jpg",
             artist = new { id = 123, name = "Test Artist" },
+            tracklist = "https://api.deezer.com/album/456789/tracks"
+        };
+
+        var deezerTracklistResponse = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = 111,
+                    title = "Track 1",
+                    duration = 180,
+                    track_position = 1,
+                    artist = new { id = 123, name = "Test Artist" }
+                },
+                new
+                {
+                    id = 222,
+                    title = "Track 2",
+                    duration = 200,
+                    track_position = 2,
+                    artist = new { id = 123, name = "Test Artist" }
+                }
+            }
+        };
+
+        SetupSequentialHttpResponses(
+            JsonSerializer.Serialize(deezerResponse),
+            JsonSerializer.Serialize(deezerTracklistResponse));
+
+        // Act
+        var result = await _service.GetAlbumAsync("deezer", "456789");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("ext-deezer-album-456789", result.Id);
+        Assert.Equal("Test Album", result.Title);
+        Assert.Equal("Test Artist", result.Artist);
+        Assert.Equal(2, result.Songs.Count);
+        Assert.Equal("Track 1", result.Songs[0].Title);
+        Assert.Equal("Track 2", result.Songs[1].Title);
+    }
+
+    [Fact]
+    public async Task GetAlbumAsync_WithDeezerProvider_ReturnsAllTracksWithPaginatedTracklist()
+    {
+        // Arrange
+        var deezerResponse = new
+        {
+            id = 456789,
+            title = "Test Album",
+            nb_tracks = 4,
+            release_date = "2023-05-20",
+            cover_medium = "https://example.com/album.jpg",
+            artist = new { id = 123, name = "Test Artist" },
+            tracklist = "https://api.deezer.com/album/456789/tracks"
+        };
+
+        var tracklistPage1 = new
+        {
+            data = new[]
+            {
+                new { id = 111, title = "Track 1", duration = 180, track_position = 1, artist = new { id = 123, name = "Test Artist" } },
+                new { id = 222, title = "Track 2", duration = 200, track_position = 2, artist = new { id = 123, name = "Test Artist" } }
+            },
+            next = "https://api.deezer.com/album/456789/tracks?limit=1000&index=1000"
+        };
+
+        var tracklistPage2 = new
+        {
+            data = new[]
+            {
+                new { id = 333, title = "Track 3", duration = 210, track_position = 3, artist = new { id = 123, name = "Test Artist" } },
+                new { id = 444, title = "Track 4", duration = 220, track_position = 4, artist = new { id = 123, name = "Test Artist" } }
+            }
+        };
+
+        SetupSequentialHttpResponses(
+            JsonSerializer.Serialize(deezerResponse),
+            JsonSerializer.Serialize(tracklistPage1),
+            JsonSerializer.Serialize(tracklistPage2));
+
+        // Act
+        var result = await _service.GetAlbumAsync("deezer", "456789");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(4, result.Songs.Count);
+        Assert.Equal("Track 1", result.Songs[0].Title);
+        Assert.Equal("Track 2", result.Songs[1].Title);
+        Assert.Equal("Track 3", result.Songs[2].Title);
+        Assert.Equal("Track 4", result.Songs[3].Title);
+    }
+
+    [Fact]
+    public async Task GetAlbumAsync_WithDeezerProvider_WithoutTracklistUrlFallsBackToTracksData()
+    {
+        // Arrange
+        var deezerResponse = new
+        {
+            id = 456789,
+            title = "Test Album",
+            nb_tracks = 2,
+            release_date = "2023-05-20",
+            cover_medium = "https://example.com/album.jpg",
+            artist = new { id = 123, name = "Test Artist" },
             tracks = new
             {
                 data = new[]
@@ -267,9 +373,6 @@ public class DeezerMetadataServiceTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal("ext-deezer-album-456789", result.Id);
-        Assert.Equal("Test Album", result.Title);
-        Assert.Equal("Test Artist", result.Artist);
         Assert.Equal(2, result.Songs.Count);
         Assert.Equal("Track 1", result.Songs[0].Title);
         Assert.Equal("Track 2", result.Songs[1].Title);
@@ -298,6 +401,25 @@ public class DeezerMetadataServiceTests
                 StatusCode = statusCode,
                 Content = new StringContent(content)
             });
+    }
+
+    private void SetupSequentialHttpResponses(params string[] contents)
+    {
+        var seq = _httpMessageHandlerMock
+            .Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        foreach (var content in contents)
+        {
+            seq = seq.ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(content)
+            });
+        }
     }
 
     #region Explicit Filter Tests
@@ -492,7 +614,7 @@ public class DeezerMetadataServiceTests
     {
         // Arrange
         _service = CreateService(new SubsonicSettings { ExplicitFilter = ExplicitFilter.ExplicitOnly });
-        
+
         var deezerResponse = new
         {
             id = 456789,
@@ -501,42 +623,43 @@ public class DeezerMetadataServiceTests
             release_date = "2023-05-20",
             cover_medium = "https://example.com/album.jpg",
             artist = new { id = 123, name = "Test Artist" },
-            tracks = new
+            tracklist = "https://api.deezer.com/album/456789/tracks"
+        };
+
+        var deezerTracklistResponse = new
+        {
+            data = new object[]
             {
-                data = new object[]
+                new
                 {
-                    new
-                    {
-                        id = 111,
-                        title = "Explicit Track",
-                        duration = 180,
-                        explicit_content_lyrics = 1,
-                        artist = new { id = 123, name = "Test Artist" },
-                        album = new { id = 456789, title = "Test Album", cover_medium = "https://example.com/album.jpg" }
-                    },
-                    new
-                    {
-                        id = 222,
-                        title = "Clean Version Track",
-                        duration = 200,
-                        explicit_content_lyrics = 3, // Should be excluded
-                        artist = new { id = 123, name = "Test Artist" },
-                        album = new { id = 456789, title = "Test Album", cover_medium = "https://example.com/album.jpg" }
-                    },
-                    new
-                    {
-                        id = 333,
-                        title = "Naturally Clean Track",
-                        duration = 220,
-                        explicit_content_lyrics = 0,
-                        artist = new { id = 123, name = "Test Artist" },
-                        album = new { id = 456789, title = "Test Album", cover_medium = "https://example.com/album.jpg" }
-                    }
+                    id = 111,
+                    title = "Explicit Track",
+                    duration = 180,
+                    explicit_content_lyrics = 1,
+                    artist = new { id = 123, name = "Test Artist" }
+                },
+                new
+                {
+                    id = 222,
+                    title = "Clean Version Track",
+                    duration = 200,
+                    explicit_content_lyrics = 3, // Should be excluded
+                    artist = new { id = 123, name = "Test Artist" }
+                },
+                new
+                {
+                    id = 333,
+                    title = "Naturally Clean Track",
+                    duration = 220,
+                    explicit_content_lyrics = 0,
+                    artist = new { id = 123, name = "Test Artist" }
                 }
             }
         };
 
-        SetupHttpResponse(JsonSerializer.Serialize(deezerResponse));
+        SetupSequentialHttpResponses(
+            JsonSerializer.Serialize(deezerResponse),
+            JsonSerializer.Serialize(deezerTracklistResponse));
 
         // Act
         var result = await _service.GetAlbumAsync("deezer", "456789");

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -221,7 +221,58 @@ public class DeezerMetadataService : IMusicMetadataService
         if (albumElement.TryGetProperty("error", out _)) return null;
         
         var album = ParseDeezerAlbum(albumElement);
-        
+
+        // Deezer /album/{id} embeds only the first 25 tracks in tracks.data.
+        // Use the tracklist endpoint and follow pagination to load all tracks.
+        if (albumElement.TryGetProperty("tracklist", out var tracklistEl))
+        {
+            var tracklistUrl = tracklistEl.GetString();
+            if (!string.IsNullOrWhiteSpace(tracklistUrl))
+            {
+                var nextPageUrl = $"{tracklistUrl}?limit=1000";
+                int trackIndex = 1;
+
+                while (!string.IsNullOrWhiteSpace(nextPageUrl))
+                {
+                    var tracklistResponse = await _httpClient.GetAsync(nextPageUrl);
+                    if (!tracklistResponse.IsSuccessStatusCode) break;
+
+                    var tracklistJson = await tracklistResponse.Content.ReadAsStringAsync();
+                    var tracklistElement = JsonDocument.Parse(tracklistJson).RootElement;
+
+                    if (!tracklistElement.TryGetProperty("data", out var pageTracks)) break;
+
+                    foreach (var track in pageTracks.EnumerateArray())
+                    {
+                        // Pass the album artist to ensure proper folder organization
+                        var song = ParseDeezerTrack(track, trackIndex, album.Artist);
+
+                        // Ensure album metadata is set (tracks in album response may not have full album object)
+                        song.Album = album.Title;
+                        song.AlbumId = album.Id;
+                        song.AlbumArtist = album.Artist;
+                        song.Year ??= album.Year;
+                        song.Genre ??= album.Genre;
+                        song.ReleaseType ??= album.ReleaseType;
+                        song.TotalTracks ??= album.SongCount;
+
+                        if (ShouldIncludeSong(song))
+                        {
+                            album.Songs.Add(song);
+                        }
+                        trackIndex++;
+                    }
+
+                    nextPageUrl = tracklistElement.TryGetProperty("next", out var nextEl)
+                        ? nextEl.GetString()
+                        : null;
+                }
+
+                return album;
+            }
+        }
+
+        // Fallback for unexpected responses without a tracklist URL.
         // Get album songs
         if (albumElement.TryGetProperty("tracks", out var tracks) &&
             tracks.TryGetProperty("data", out var tracksData))
@@ -231,7 +282,7 @@ public class DeezerMetadataService : IMusicMetadataService
             {
                 // Pass the album artist to ensure proper folder organization
                 var song = ParseDeezerTrack(track, trackIndex, album.Artist);
-                
+
                 // Ensure album metadata is set (tracks in album response may not have full album object)
                 song.Album = album.Title;
                 song.AlbumId = album.Id;
@@ -248,7 +299,7 @@ public class DeezerMetadataService : IMusicMetadataService
                 trackIndex++;
             }
         }
-        
+
         return album;
     }
 


### PR DESCRIPTION
The Deezer /album/{id} response only embeds the first 25 tracks, so albums with more tracks were truncated. This mirrors the existing playlist implementation that already follows the tracklist URL with pagination.

**Tests all passed succesfully (sorry for the German...):**
PS D:\GitHub\octo-fiesta> dotnet test
Wiederherstellung abgeschlossen (0,5s)
  octo-fiesta Erfolgreich (0,3s) → octo-fiesta\bin\Debug\net9.0\octo-fiesta.dll
  octo-fiesta.Tests Erfolgreich (0,1s) → octo-fiesta.Tests\bin\Debug\net9.0\octo-fiesta.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.15)
[xUnit.net 00:00:00.55]   Discovering: octo-fiesta.Tests
[xUnit.net 00:00:00.67]   Discovered:  octo-fiesta.Tests
[xUnit.net 00:00:00.67]   Starting:    octo-fiesta.Tests
[xUnit.net 00:00:01.68]   Finished:    octo-fiesta.Tests
  octo-fiesta.Tests Test Erfolgreich (3,5s)

Testzusammenfassung: insgesamt: 524; fehlgeschlagen: 0; erfolgreich: 524; übersprungen: 0; Dauer: 3,4 Sek.
Erstellen von Erfolgreich in 4,6s

**Example album to test with:**
14587650

**Remark:**
I sticked to the existing implementation for playlists to have a similar behavior for albums. Nevertheless the album endpoint has a response value "nb_tracks" that indicates the number of tracks. To improve the performance and to reduce the calls, this value could be parsed and only if more then 25 tracks are in the album, the tracklist is used. Let me know in case I should modify it into this direction.