### PR TITLE
[WIP] Fix multiple artists

### DIFF
--- a/octo-fiesta.Tests/QobuzMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/QobuzMetadataServiceTests.cs
@@ -552,7 +552,7 @@ public class QobuzMetadataServiceTests
         Assert.Equal("℗ 1959 Columbia Records", result.Copyright);
         Assert.Equal(1959, result.Year);
         Assert.Equal("1959-12-14", result.ReleaseDate);
-        Assert.Contains("Paul Desmond", result.Contributors);
+        Assert.Contains("Paul Desmond", result.Contributors.Select(c => c.Name));
         Assert.Equal("Jazz, Cool Jazz", result.Genre);
     }
     

--- a/octo-fiesta/Models/Domain/Song.cs
+++ b/octo-fiesta/Models/Domain/Song.cs
@@ -68,13 +68,13 @@ public class Song
     /// All performing artists (for multi-artist tracks).
     /// First entry should match Artist. Used for file tagging (Performers field).
     /// </summary>
-    public List<string> Artists { get; set; } = new();
-    
+    public List<Artist> Artists { get; set; } = new();
+
     /// <summary>
     /// Contributing artists (features, etc.)
     /// </summary>
-    public List<string> Contributors { get; set; } = new();
-    
+    public List<Artist> Contributors { get; set; } = new();
+
     /// <summary>
     /// Indicates whether the song is available locally or needs to be downloaded
     /// </summary>

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -794,7 +794,7 @@ public abstract class BaseDownloadService : IDownloadService
             // Basic metadata
             tagFile.Tag.Title = song.Title;
             tagFile.Tag.Performers = song.Artists.Count > 0 
-                ? song.Artists.ToArray() 
+                ? song.Artists.Select(a => a.Name).ToArray() 
                 : new[] { song.Artist };
             tagFile.Tag.Album = song.Album;
             tagFile.Tag.AlbumArtists = new[] { !string.IsNullOrEmpty(song.AlbumArtist) ? song.AlbumArtist : song.Artist };
@@ -818,7 +818,7 @@ public abstract class BaseDownloadService : IDownloadService
                 tagFile.Tag.BeatsPerMinute = (uint)song.Bpm.Value;
 
             if (song.Contributors.Count > 0)
-                tagFile.Tag.Composers = song.Contributors.ToArray();
+                tagFile.Tag.Composers = song.Contributors.Select(c => c.Name).ToArray();
 
             if (!string.IsNullOrEmpty(song.Copyright))
                 tagFile.Tag.Copyright = song.Copyright;

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -634,10 +634,6 @@ public abstract class BaseDownloadService : IDownloadService
                 var album = await MetadataService.GetAlbumAsync(externalProvider, albumExternalId);
                 if (album != null)
                 {
-                    // Find the track in the album to get full metadata including AlbumArtist
-                    song = album.Songs.FirstOrDefault(s => s.ExternalId == externalId);
-
-                    // If track not found in album (e.g., bonus track), use tempSong with album artist
                     if (song == null && !string.IsNullOrEmpty(album.Artist))
                     {
                         tempSong.AlbumArtist = album.Artist;

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -357,22 +357,19 @@ public class DeezerMetadataService : IMusicMetadataService
         int? explicitContentLyrics = track.TryGetProperty("explicit_content_lyrics", out var ecl) 
             ? ecl.GetInt32() 
             : null;
-        
-        var mainArtist = track.TryGetProperty("artist", out var artist) 
-            ? artist.GetProperty("name").GetString() ?? "" 
-            : "";
-        
+
+
+        var mainArtist = track.TryGetProperty("artist", out var artist) ? ParseDeezerArtist(artist) : new Artist { Name = albumArtist ?? "" };
+
+
         return new Song
         {
             Id = $"ext-deezer-song-{externalId}",
             Title = track.GetProperty("title").GetString() ?? "",
-            Artist = mainArtist,
-            Artists = !string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>(),
-            ArtistId = track.TryGetProperty("artist", out var artistForId) 
-                ? $"ext-deezer-artist-{artistForId.GetProperty("id").GetInt64()}" 
-                : null,
-            Album = track.TryGetProperty("album", out var album) 
-                ? album.GetProperty("title").GetString() ?? "" 
+            Artist = mainArtist.Name,
+            ArtistId = mainArtist?.Id,
+            Album = track.TryGetProperty("album", out var album)
+                ? album.GetProperty("title").GetString() ?? ""
                 : "",
             AlbumId = track.TryGetProperty("album", out var albumForId) 
                 ? $"ext-deezer-album-{albumForId.GetProperty("id").GetInt64()}" 
@@ -450,17 +447,12 @@ public class DeezerMetadataService : IMusicMetadataService
         }
         
         // Contributors
-        var contributors = new List<string>();
+        var contributors = new List<Artist>();
         if (track.TryGetProperty("contributors", out var contribs))
         {
             foreach (var contrib in contribs.EnumerateArray())
             {
-                if (contrib.TryGetProperty("name", out var contribName))
-                {
-                    var name = contribName.GetString();
-                    if (!string.IsNullOrEmpty(name))
-                        contributors.Add(name);
-                }
+                contributors.Add(ParseDeezerArtist(contrib));
             }
         }
         
@@ -491,22 +483,18 @@ public class DeezerMetadataService : IMusicMetadataService
         int? explicitContentLyrics = track.TryGetProperty("explicit_content_lyrics", out var ecl) 
             ? ecl.GetInt32() 
             : null;
-        
-        var mainArtist = track.TryGetProperty("artist", out var artist) 
-            ? artist.GetProperty("name").GetString() ?? "" 
-            : "";
-        
+
+        var mainArtist = track.TryGetProperty("artist", out var artist) ? ParseDeezerArtist(artist) : new Artist { Name = albumArtist ?? "" };
+
         return new Song
         {
             Id = $"ext-deezer-song-{externalId}",
             Title = track.GetProperty("title").GetString() ?? "",
-            Artist = mainArtist,
-            Artists = contributors.Count > 0 ? contributors : (!string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>()),
-            ArtistId = track.TryGetProperty("artist", out var artistForId) 
-                ? $"ext-deezer-artist-{artistForId.GetProperty("id").GetInt64()}" 
-                : null,
-            Album = track.TryGetProperty("album", out var album) 
-                ? album.GetProperty("title").GetString() ?? "" 
+            Artist = mainArtist.Name,
+            ArtistId = mainArtist?.Id,
+            Artists = contributors,
+            Album = track.TryGetProperty("album", out var album)
+                ? album.GetProperty("title").GetString() ?? ""
                 : "",
             AlbumId = track.TryGetProperty("album", out var albumForId) 
                 ? $"ext-deezer-album-{albumForId.GetProperty("id").GetInt64()}" 
@@ -521,7 +509,6 @@ public class DeezerMetadataService : IMusicMetadataService
             Isrc = isrc,
             ReleaseDate = releaseDate,
             AlbumArtist = albumArtist,
-            Contributors = contributors,
             CoverArtUrl = coverMedium,
             CoverArtUrlLarge = coverLarge,
             IsLocal = false,

--- a/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
@@ -550,6 +550,10 @@ public class QobuzMetadataService : IMusicMetadataService
         var performerName = track.TryGetProperty("performer", out var performer)
             ? performer.GetProperty("name").GetString() ?? ""
             : "";
+
+        var performerId = track.TryGetProperty("performer", out var performerForId)
+            ? $"ext-qobuz-artist-{GetIdAsString(performerForId.GetProperty("id"))}"
+            : null;
         
         var albumTitle = track.TryGetProperty("album", out var album)
             ? album.GetProperty("title").GetString() ?? ""
@@ -570,10 +574,8 @@ public class QobuzMetadataService : IMusicMetadataService
             Id = $"ext-qobuz-song-{externalId}",
             Title = title,
             Artist = performerName,
-            Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),
-            ArtistId = track.TryGetProperty("performer", out var performerForId)
-                ? $"ext-qobuz-artist-{GetIdAsString(performerForId.GetProperty("id"))}"
-                : null,
+            Artists = !string.IsNullOrEmpty(performerName) ? new List<Artist> { new Artist { Name = performerName, Id = performerId } } : new List<Artist>(),
+            ArtistId = performerId,
             Album = albumTitle,
             AlbumId = albumId,
             AlbumArtist = albumArtist,
@@ -599,9 +601,13 @@ public class QobuzMetadataService : IMusicMetadataService
         
         // Add additional metadata for full track
         if (track.TryGetProperty("composer", out var composer) &&
-            composer.TryGetProperty("name", out var composerName))
+            composer.TryGetProperty("name", out var composerName) &&
+            composer.TryGetProperty("id", out var composerId))
         {
-            song.Contributors = new List<string> { composerName.GetString() ?? "" };
+            song.Contributors = new List<Artist> { new Artist {
+                Name = composerName.GetString() ?? "",
+                Id = $"ext-qobuz-artist-{GetIdAsString(composerId)}" ?? null
+            } };
         }
         
         if (track.TryGetProperty("isrc", out var isrc))

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -804,21 +804,22 @@ public class SquidWTFMetadataService : IMusicMetadataService
         }
         
         // Get composers from composer field
-        var contributors = new List<string>();
+        var contributors = new List<Artist>();
         if (track.Composer != null && !string.IsNullOrEmpty(track.Composer.Name))
         {
-            contributors.Add(track.Composer.Name);
+            contributors.Add(new Artist { Name = track.Composer.Name });
         }
         
         var performerName = track.Performer?.Name ?? "";
+        var performerId = track.Performer != null ? $"ext-squidwtf-artist-{track.Performer.Id}" : null;
         
         return new Song
         {
             Id = $"ext-squidwtf-song-{externalId}",
             Title = track.Title ?? "",
             Artist = performerName,
-            Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),
-            ArtistId = track.Performer != null ? $"ext-squidwtf-artist-{track.Performer.Id}" : null,
+            Artists = !string.IsNullOrEmpty(performerName) ? new List<Artist> { new Artist { Name = performerName, Id = performerId } } : new List<Artist>(),
+            ArtistId = performerId,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,
@@ -902,16 +903,22 @@ public class SquidWTFMetadataService : IMusicMetadataService
             }
         }
         
-        var artistNames = track.Artists?
+        var artists = track.Artists?
             .Where(a => !string.IsNullOrEmpty(a.Name))
-            .Select(a => a.Name!)
-            .ToList() ?? new List<string>();
+            .Select(a => MapTidalArtistToArtist(a))
+            .ToList() ?? new List<Artist>();
         
-        var mainArtistName = track.Artist?.Name ?? (artistNames.FirstOrDefault() ?? "");
-        
+        var mainArtistName = track.Artist?.Name ?? (artists.FirstOrDefault()?.Name ?? "");
+
+        var mainArtistId = track.Artist != null 
+            ? $"ext-squidwtf-artist-{track.Artist.Id}" 
+            : (track.Artists?.FirstOrDefault() is { } firstArtist 
+                ? $"ext-squidwtf-artist-{firstArtist.Id}" 
+                : null);
+
         // Ensure main artist is first in the list
-        if (artistNames.Count == 0 && !string.IsNullOrEmpty(mainArtistName))
-            artistNames.Add(mainArtistName);
+        if (artists.Count == 0 && !string.IsNullOrEmpty(mainArtistName) && mainArtistId != null)
+            artists.Add(new Artist { Name = mainArtistName, Id = mainArtistId });
 
         var title = track.Title ?? "";
         if (!string.IsNullOrEmpty(track.Version))
@@ -922,12 +929,8 @@ public class SquidWTFMetadataService : IMusicMetadataService
             Id = $"ext-squidwtf-song-{externalId}",
             Title = title,
             Artist = mainArtistName,
-            Artists = artistNames,
-            ArtistId = track.Artist != null 
-                ? $"ext-squidwtf-artist-{track.Artist.Id}" 
-                : (track.Artists?.FirstOrDefault() is { } firstArtist 
-                    ? $"ext-squidwtf-artist-{firstArtist.Id}" 
-                    : null),
+            Artists = artists,
+            ArtistId = mainArtistId,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,
@@ -962,28 +965,30 @@ public class SquidWTFMetadataService : IMusicMetadataService
             }
         }
         
-        var artistNames = track.Artists?
+        var artists = track.Artists?
             .Where(a => !string.IsNullOrEmpty(a.Name))
-            .Select(a => a.Name!)
-            .ToList() ?? new List<string>();
+            .Select(a => MapTidalArtistToArtist(a))
+            .ToList() ?? new List<Artist>();
         
-        var mainArtistName = track.Artist?.Name ?? (artistNames.FirstOrDefault() ?? "");
-        
+        var mainArtistName = track.Artist?.Name ?? (artists.FirstOrDefault()?.Name ?? "");
+
+        var mainArtistId = track.Artist != null 
+            ? $"ext-squidwtf-artist-{track.Artist.Id}" 
+            : (track.Artists?.FirstOrDefault() is { } firstTrackInfoArtist 
+                ? $"ext-squidwtf-artist-{firstTrackInfoArtist.Id}" 
+                : null);
+
         // Ensure main artist is first in the list
-        if (artistNames.Count == 0 && !string.IsNullOrEmpty(mainArtistName))
-            artistNames.Add(mainArtistName);
+        if (artists.Count == 0 && !string.IsNullOrEmpty(mainArtistName) && mainArtistId != null)
+            artists.Add(new Artist { Name = mainArtistName, Id = mainArtistId });
         
         return new Song
         {
             Id = $"ext-squidwtf-song-{externalId}",
             Title = track.Title ?? "",
             Artist = mainArtistName,
-            Artists = artistNames,
-            ArtistId = track.Artist != null 
-                ? $"ext-squidwtf-artist-{track.Artist.Id}" 
-                : (track.Artists?.FirstOrDefault() is { } firstTrackInfoArtist 
-                    ? $"ext-squidwtf-artist-{firstTrackInfoArtist.Id}" 
-                    : null),
+            Artists = artists,
+            ArtistId = mainArtistId,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,

--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -322,11 +322,6 @@ public class SubsonicResponseBuilder
             size = (long)bitRate * 125L * (long)(song.Duration ?? 0);
         }
 
-        var sourceNames = song.Artists.Count > 0 ? song.Artists : song.Contributors;
-        var artistsList = sourceNames
-            .Select(name => new Dictionary<string, object> { ["name"] = name })
-            .ToList<object>();
-
         var result = new Dictionary<string, object>
         {
             ["id"] = song.Id,
@@ -335,7 +330,7 @@ public class SubsonicResponseBuilder
             ["title"] = song.Title,
             ["album"] = song.Album ?? "",
             ["artist"] = song.Artist ?? "",
-            ["artists"] = artistsList,
+            ["artists"] = song.Artists ?? new List<Artist>(),
             ["albumId"] = song.AlbumId ?? "",
             ["artistId"] = song.ArtistId ?? "",
             ["duration"] = song.Duration ?? 0,

--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -23,7 +23,7 @@ public class SubsonicResponseBuilder
         {
             return CreateJsonResponse(new { status = "ok", version = SubsonicVersion });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
@@ -42,14 +42,14 @@ public class SubsonicResponseBuilder
     {
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "failed", 
+            return CreateJsonResponse(new
+            {
+                status = "failed",
                 version = SubsonicVersion,
                 error = new { code, message }
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
@@ -71,14 +71,14 @@ public class SubsonicResponseBuilder
     {
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "ok", 
+            return CreateJsonResponse(new
+            {
+                status = "ok",
                 version = SubsonicVersion,
                 song = ConvertSongToJson(song)
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
@@ -96,12 +96,12 @@ public class SubsonicResponseBuilder
     public IActionResult CreateAlbumResponse(string format, Album album)
     {
         var totalDuration = album.Songs.Sum(s => s.Duration ?? 0);
-        
+
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "ok", 
+            return CreateJsonResponse(new
+            {
+                status = "ok",
                 version = SubsonicVersion,
                 album = new
                 {
@@ -121,7 +121,7 @@ public class SubsonicResponseBuilder
                 }
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
@@ -144,7 +144,7 @@ public class SubsonicResponseBuilder
         );
         return new ContentResult { Content = doc.ToString(), ContentType = "application/xml; charset=utf-8" };
     }
-    
+
     /// <summary>
     /// Creates a Subsonic response for a playlist represented as an album.
     /// Playlists appear as albums with genre "Playlist".
@@ -152,21 +152,21 @@ public class SubsonicResponseBuilder
     public IActionResult CreatePlaylistAsAlbumResponse(string format, ExternalPlaylist playlist, List<Song> tracks)
     {
         var totalDuration = tracks.Sum(s => s.Duration ?? 0);
-        
+
         // Build artist name with emoji and curator
         var artistName = $"🎵 {char.ToUpper(playlist.Provider[0])}{playlist.Provider.Substring(1)}";
         if (!string.IsNullOrEmpty(playlist.CuratorName))
         {
             artistName += $" {playlist.CuratorName}";
         }
-        
+
         var artistId = $"curator-{playlist.Provider}-{playlist.CuratorName?.ToLowerInvariant().Replace(" ", "-") ?? "unknown"}";
-        
+
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "ok", 
+            return CreateJsonResponse(new
+            {
+                status = "ok",
                 version = SubsonicVersion,
                 album = new
                 {
@@ -191,7 +191,7 @@ public class SubsonicResponseBuilder
                 }
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var albumElement = new XElement(ns + "album",
             new XAttribute("id", playlist.Id),
@@ -205,12 +205,12 @@ public class SubsonicResponseBuilder
             new XAttribute("displayArtist", artistName),
             new XAttribute("created", playlist.CreatedDate.HasValue ? playlist.CreatedDate.Value.ToUniversalTime().ToString("o") : System.DateTime.UtcNow.ToString("o"))
         );
-        
+
         if (playlist.CreatedDate.HasValue)
         {
             albumElement.Add(new XAttribute("year", playlist.CreatedDate.Value.Year));
         }
-        
+
         // Add songs
         foreach (var song in tracks)
         {
@@ -219,7 +219,7 @@ public class SubsonicResponseBuilder
             songXml.SetAttributeValue("parent", playlist.Id);
             albumElement.Add(songXml);
         }
-        
+
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
                 new XAttribute("status", "ok"),
@@ -237,9 +237,9 @@ public class SubsonicResponseBuilder
     {
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "ok", 
+            return CreateJsonResponse(new
+            {
+                status = "ok",
                 version = SubsonicVersion,
                 artist = new
                 {
@@ -252,7 +252,7 @@ public class SubsonicResponseBuilder
                 }
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
@@ -322,6 +322,11 @@ public class SubsonicResponseBuilder
             size = (long)bitRate * 125L * (long)(song.Duration ?? 0);
         }
 
+        var sourceNames = song.Artists.Count > 0 ? song.Artists : song.Contributors;
+        var artistsList = sourceNames
+            .Select(name => new Dictionary<string, object> { ["name"] = name })
+            .ToList<object>();
+
         var result = new Dictionary<string, object>
         {
             ["id"] = song.Id,
@@ -330,6 +335,7 @@ public class SubsonicResponseBuilder
             ["title"] = song.Title,
             ["album"] = song.Album ?? "",
             ["artist"] = song.Artist ?? "",
+            ["artists"] = artistsList,
             ["albumId"] = song.AlbumId ?? "",
             ["artistId"] = song.ArtistId ?? "",
             ["duration"] = song.Duration ?? 0,

--- a/octo-fiesta/Services/Yandex/YandexMetadataService.cs
+++ b/octo-fiesta/Services/Yandex/YandexMetadataService.cs
@@ -338,7 +338,10 @@ public class YandexMetadataService : IMusicMetadataService
             AlbumArtist = yandexAlbum?.Artists.FirstOrDefault()?.Name,
             Composer = null,
             Label = yandexAlbum?.Labels?.FirstOrDefault()?.Name,
-            Artists = yandexTrack.Artists?.Select(a => a.Name)?.ToList() ?? [],
+            Artists = yandexTrack.Artists?.Select(x => new Artist {
+                Name = x.Name ?? String.Empty,
+                Id = ArtistPrefix + x.Id.ToString()
+            })?.ToList() ?? [],
             Contributors = [],
             IsLocal = false,
             ExternalProvider = ProviderName,


### PR DESCRIPTION
Fixes #222

Tested to work with Supersonic client and Deezer provider.

Multiple artists don't show up in the album view because they aren't present in the Deezer album metadata (only in the track metadata). 


I had to do some refactoring impacting all providers to use `Artist` instead of `string` for the artists list.

Are you interested in merging this? 