### PR TITLE
Track and album version support for yandex music

### DIFF
--- a/octo-fiesta/Models/Yandex/YandexApiResponses.cs
+++ b/octo-fiesta/Models/Yandex/YandexApiResponses.cs
@@ -46,6 +46,9 @@ public class YandexTrack
     [JsonPropertyName("title")]
     public string? Title { get; set; } = string.Empty;
 
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
     /// <summary>
     /// Content warning. Known values: 'explicit', 'clean'
     /// </summary>
@@ -98,6 +101,9 @@ public class YandexTrackAlbum
 
     [JsonPropertyName("year")]
     public int? Year { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
 
     [JsonPropertyName("releaseDate")]
     public string? ReleaseDate { get; set; }
@@ -222,6 +228,9 @@ public class YandexAlbumWithTracks
 
     [JsonPropertyName("year")]
     public int? Year { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
 
     [JsonPropertyName("trackCount")]
     public int? TrackCount { get; set; }

--- a/octo-fiesta/Services/Yandex/YandexMetadataService.cs
+++ b/octo-fiesta/Services/Yandex/YandexMetadataService.cs
@@ -318,13 +318,25 @@ public class YandexMetadataService : IMusicMetadataService
         else if (yandexTrack.ContentWarning == "clean") explicitWarning = 3;
         else explicitWarning = 0;
 
+        string title = yandexTrack.Title ?? string.Empty;
+        if (!String.IsNullOrEmpty(yandexTrack.Version))
+        {
+            title += $" ({yandexTrack.Version})";
+        }
+
+        string albumTitle = yandexAlbum?.Title ?? string.Empty;
+        if (!String.IsNullOrEmpty(yandexAlbum?.Version))
+        {
+            albumTitle += $" ({yandexAlbum.Version})";
+        }
+
         return new Song
         {
             Id = SongPrefix + externalTrackId,
-            Title = yandexTrack.Title ?? string.Empty,
+            Title = title,
             Artist = yandexArtist?.Name ?? string.Empty,
             ArtistId = string.IsNullOrEmpty(externalArtistId) ? null : ArtistPrefix + externalArtistId,
-            Album = yandexAlbum?.Title ?? string.Empty,
+            Album = albumTitle,
             AlbumId = string.IsNullOrEmpty(externalAlbumId) ? null : AlbumPrefix + externalAlbumId,
             Duration = yandexTrack.DurationMs / 1000,
             Track = yandexAlbum?.TrackPosition?.Index,
@@ -383,10 +395,17 @@ public class YandexMetadataService : IMusicMetadataService
         string? externalArtistId = yandexArtist?.Id.ToString();
 
         string? coverUri = yandexAlbum.CoverUri ?? yandexAlbum.Cover?.Uri ?? yandexAlbum.OgImage;
+
+        string title = yandexAlbum.Title ?? string.Empty;
+        if (!String.IsNullOrEmpty(yandexAlbum.Version))
+        {
+            title += $" ({yandexAlbum.Version})";
+        }
+
         return new Album
         {
             Id = AlbumPrefix + externalId,
-            Title = yandexAlbum.Title ?? string.Empty,
+            Title = title,
             Artist = yandexArtist?.Name ?? string.Empty,
             ArtistId = string.IsNullOrEmpty(externalArtistId) ? null : ArtistPrefix + externalArtistId,
             Year = yandexAlbum.Year,


### PR DESCRIPTION
Basically adds support for #206 to Yandex Music provider. 

Feishin screenshots before/after:
- before: <img width="480" alt="Screenshot 2026-05-04 at 00 44 04" src="https://github.com/user-attachments/assets/a00df341-e962-493d-9ea0-7b3593050b3b" />
- after:  <img width="480" alt="Screenshot 2026-05-04 at 01 04 32" src="https://github.com/user-attachments/assets/59c3d026-a8bd-4caf-ab51-d4b11bfb2b2f" />
