### PR TITLE
fix(deezer): propagate album cover art to paginated tracklist tracks

### DIFF
--- a/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
@@ -275,6 +275,7 @@ public class DeezerMetadataServiceTests
         Assert.Equal(2, result.Songs.Count);
         Assert.Equal("Track 1", result.Songs[0].Title);
         Assert.Equal("Track 2", result.Songs[1].Title);
+        Assert.All(result.Songs, s => Assert.Equal("https://example.com/album.jpg", s.CoverArtUrl));
     }
 
     [Fact]
@@ -326,6 +327,7 @@ public class DeezerMetadataServiceTests
         Assert.Equal("Track 2", result.Songs[1].Title);
         Assert.Equal("Track 3", result.Songs[2].Title);
         Assert.Equal("Track 4", result.Songs[3].Title);
+        Assert.All(result.Songs, s => Assert.Equal("https://example.com/album.jpg", s.CoverArtUrl));
     }
 
     [Fact]

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -255,6 +255,8 @@ public class DeezerMetadataService : IMusicMetadataService
                         song.Genre ??= album.Genre;
                         song.ReleaseType ??= album.ReleaseType;
                         song.TotalTracks ??= album.SongCount;
+                        song.CoverArtUrl ??= album.CoverArtUrl;
+                        song.CoverArtUrlLarge ??= album.CoverArtUrlLarge;
 
                         if (ShouldIncludeSong(song))
                         {
@@ -291,6 +293,8 @@ public class DeezerMetadataService : IMusicMetadataService
                 song.Genre ??= album.Genre;
                 song.ReleaseType ??= album.ReleaseType;
                 song.TotalTracks ??= album.SongCount;
+                song.CoverArtUrl ??= album.CoverArtUrl;
+                song.CoverArtUrlLarge ??= album.CoverArtUrlLarge;
 
                 if (ShouldIncludeSong(song))
                 {


### PR DESCRIPTION
Sorry, my last PR broke the cover download for albums. The tracklist endpoint for albums returns lightweight track objects without an album sub-object, so CoverArtUrl/CoverArtUrlLarge were never set for albums with more than 25 tracks. Now falls back to the album-level cover URLs when the track does not carry its own.

Tests are passing.