### PR TITLE
cleanup: remove Song.Id field compute ID at output

### DIFF
--- a/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/DeezerMetadataServiceTests.cs
@@ -65,7 +65,6 @@ public class DeezerMetadataServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.Single(result);
-        Assert.Equal("ext-deezer-song-123456", result[0].Id);
         Assert.Equal("Test Song", result[0].Title);
         Assert.Equal("Test Artist", result[0].Artist);
         Assert.Equal("Test Album", result[0].Album);
@@ -180,7 +179,6 @@ public class DeezerMetadataServiceTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal("ext-deezer-song-123456", result.Id);
         Assert.Equal("Test Song", result.Title);
     }
 
@@ -890,7 +888,6 @@ public class DeezerMetadataServiceTests
         Assert.Equal(2, result.Count);
         Assert.Equal("Track 1", result[0].Title);
         Assert.Equal("Artist A", result[0].Artist);
-        Assert.Equal("ext-deezer-song-111", result[0].Id);
         Assert.Equal(1, result[0].Track);
         Assert.Equal(2, result[1].Track);
     }

--- a/octo-fiesta.Tests/LocalLibraryServiceTests.cs
+++ b/octo-fiesta.Tests/LocalLibraryServiceTests.cs
@@ -127,7 +127,6 @@ public class LocalLibraryServiceTests : IDisposable
         // Arrange
         var song = new Song
         {
-            Id = "ext-deezer-123456",
             Title = "Test Song",
             Artist = "Test Artist",
             Album = "Test Album",
@@ -153,7 +152,6 @@ public class LocalLibraryServiceTests : IDisposable
         // Arrange
         var song = new Song
         {
-            Id = "ext-deezer-999999",
             Title = "Deleted Song",
             Artist = "Test Artist",
             Album = "Test Album",
@@ -180,7 +178,6 @@ public class LocalLibraryServiceTests : IDisposable
         // Arrange
         var song = new Song
         {
-            Id = "local-123",
             Title = "Local Song",
             Artist = "Local Artist",
             Album = "Local Album",

--- a/octo-fiesta.Tests/QobuzMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/QobuzMetadataServiceTests.cs
@@ -297,7 +297,6 @@ public class QobuzMetadataServiceTests
         Assert.Equal("Dave Brubeck Quartet", result[0].Artist);
         Assert.Equal("My Jazz Playlist", result[0].Album); // Album should be playlist name
         Assert.Equal(1, result[0].Track); // Track index starts at 1
-        Assert.Equal("ext-qobuz-song-123456789", result[0].Id);
         Assert.Equal("qobuz", result[0].ExternalProvider);
         Assert.Equal("123456789", result[0].ExternalId);
         
@@ -306,7 +305,6 @@ public class QobuzMetadataServiceTests
         Assert.Equal("Miles Davis", result[1].Artist);
         Assert.Equal("My Jazz Playlist", result[1].Album); // Album should be playlist name
         Assert.Equal(2, result[1].Track); // Track index increments
-        Assert.Equal("ext-qobuz-song-987654321", result[1].Id);
     }
     
     [Fact]

--- a/octo-fiesta.Tests/SubsonicModelMapperTests.cs
+++ b/octo-fiesta.Tests/SubsonicModelMapperTests.cs
@@ -180,7 +180,7 @@ public class SubsonicModelMapperTests
         {
             Songs = new List<Song>
             {
-                new Song { Id = "ext1", Title = "External Song" }
+                new Song {Title = "External Song" }
             },
             Albums = new List<Album>(),
             Artists = new List<Artist>()
@@ -233,7 +233,7 @@ public class SubsonicModelMapperTests
         {
             Songs = new List<Song>
             {
-                new Song { Id = "ext1", Title = "External Song" }
+                new Song {Title = "External Song" }
             },
             Albums = new List<Album>(),
             Artists = new List<Artist>()
@@ -280,7 +280,7 @@ public class SubsonicModelMapperTests
         // Arrange
         var externalResult = new SearchResult
         {
-            Songs = new List<Song> { new Song { Id = "ext1" } },
+            Songs = new List<Song> { new Song { Title = "ext1" } },
             Albums = new List<Album> { new Album { Id = "ext2" } },
             Artists = new List<Artist> { new Artist { Id = "ext3", Name = "Artist" } }
         };

--- a/octo-fiesta.Tests/SubsonicResponseBuilderTests.cs
+++ b/octo-fiesta.Tests/SubsonicResponseBuilderTests.cs
@@ -93,7 +93,6 @@ public class SubsonicResponseBuilderTests
         // Arrange
         var song = new Song
         {
-            Id = "song123",
             Title = "Test Song",
             Artist = "Test Artist",
             Album = "Test Album",
@@ -101,7 +100,9 @@ public class SubsonicResponseBuilderTests
             Track = 5,
             Year = 2023,
             Genre = "Rock",
-            LocalPath = "/music/test.mp3"
+            LocalPath = "/music/test.mp3",
+            ExternalId = "1234",
+            ExternalProvider = "deezer"
         };
 
         // Act
@@ -113,7 +114,7 @@ public class SubsonicResponseBuilderTests
         var doc = JsonDocument.Parse(json);
         var songData = doc.RootElement.GetProperty("subsonic-response").GetProperty("song");
         
-        Assert.Equal("song123", songData.GetProperty("id").GetString());
+        Assert.Equal("ext-deezer-song-1234", songData.GetProperty("id").GetString());
         Assert.Equal("Test Song", songData.GetProperty("title").GetString());
         Assert.Equal("Test Artist", songData.GetProperty("artist").GetString());
         Assert.Equal("Test Album", songData.GetProperty("album").GetString());
@@ -125,7 +126,6 @@ public class SubsonicResponseBuilderTests
         // Arrange
         var song = new Song
         {
-            Id = "song123",
             Title = "Test Song",
             Artist = "Test Artist",
             ArtistId = "artist123",
@@ -133,7 +133,9 @@ public class SubsonicResponseBuilderTests
             AlbumId = "album123",
             Duration = 180,
             ReleaseDate = "2023-01-02",
-            IsLocal = true
+            IsLocal = true,
+            ExternalId = "1234",
+            ExternalProvider = "deezer"
         };
 
         // Act
@@ -147,7 +149,7 @@ public class SubsonicResponseBuilderTests
         var ns = doc.Root!.GetDefaultNamespace();
         var songElement = doc.Root!.Element(ns + "song");
         Assert.NotNull(songElement);
-        Assert.Equal("song123", songElement.Attribute("id")?.Value);
+        Assert.Equal("ext-deezer-song-1234", songElement.Attribute("id")?.Value);
         Assert.Equal("Test Song", songElement.Attribute("title")?.Value);
         Assert.Equal("album123", songElement.Attribute("albumId")?.Value);
         Assert.Equal("artist123", songElement.Attribute("artistId")?.Value);
@@ -178,8 +180,8 @@ public class SubsonicResponseBuilderTests
             Year = 2023,
             Songs = new List<Song>
             {
-                new Song { Id = "song1", Title = "Song 1", Duration = 180 },
-                new Song { Id = "song2", Title = "Song 2", Duration = 200 }
+                new Song { Title = "Song 1", Duration = 180 },
+                new Song { Title = "Song 2", Duration = 200 }
             }
         };
 
@@ -210,8 +212,8 @@ public class SubsonicResponseBuilderTests
             SongCount = 2,
             Songs = new List<Song>
             {
-                new Song { Id = "song1", Title = "Song 1" },
-                new Song { Id = "song2", Title = "Song 2" }
+                new Song { Title = "Song 1" },
+                new Song { Title = "Song 2" }
             }
         };
 
@@ -304,8 +306,9 @@ public class SubsonicResponseBuilderTests
         // Arrange
         var song = new Song
         {
-            Id = "song123",
-            Title = "Test Song"
+            Title = "Test Song",
+            ExternalId = "1234",
+            ExternalProvider = "deezer"
             // Other fields are null
         };
 
@@ -318,7 +321,7 @@ public class SubsonicResponseBuilderTests
         var doc = JsonDocument.Parse(json);
         var songData = doc.RootElement.GetProperty("subsonic-response").GetProperty("song");
         
-        Assert.Equal("song123", songData.GetProperty("id").GetString());
+        Assert.Equal("ext-deezer-song-1234", songData.GetProperty("id").GetString());
         Assert.Equal("Test Song", songData.GetProperty("title").GetString());
     }
 

--- a/octo-fiesta.Tests/YandexDownloadServiceTests.cs
+++ b/octo-fiesta.Tests/YandexDownloadServiceTests.cs
@@ -267,7 +267,6 @@ public class YandexDownloadServiceTests : IDisposable
             .Setup(s => s.GetSongAsync("yandex", "123456"))
             .ReturnsAsync(new Song
             {
-                Id = "ext-yandex-song-123456",
                 Title = "Test Song",
                 Artist = "Test Artist",
                 ArtistId = "ext-yandex-artist-123456",
@@ -379,7 +378,6 @@ public class YandexDownloadServiceTests : IDisposable
             .Setup(s => s.GetSongAsync("yandex", "123456"))
             .ReturnsAsync(new Song
             {
-                Id = "ext-yandex-song-123456",
                 Title = "Test Song",
                 Artist = "Test Artist",
                 ArtistId = "ext-yandex-artist-123456",
@@ -487,7 +485,6 @@ public class YandexDownloadServiceTests : IDisposable
             .Setup(s => s.GetSongAsync("yandex", "123456"))
             .ReturnsAsync(new Song
             {
-                Id = "ext-yandex-song-123456",
                 Title = "Test Song",
                 IsLocal = false,
                 ExternalProvider = "yandex",
@@ -540,7 +537,6 @@ public class YandexDownloadServiceTests : IDisposable
             .Setup(s => s.GetSongAsync("yandex", "123456"))
             .ReturnsAsync(new Song
             {
-                Id = "ext-yandex-song-123456",
                 Title = "Test Song",
                 IsLocal = false,
                 ExternalProvider = "yandex",
@@ -594,7 +590,6 @@ public class YandexDownloadServiceTests : IDisposable
             .Setup(s => s.GetSongAsync("yandex", "123456"))
             .ReturnsAsync(new Song
             {
-                Id = "ext-yandex-song-123456",
                 Title = "Test Song",
                 IsLocal = false,
                 ExternalProvider = "yandex",

--- a/octo-fiesta.Tests/YandexMetadataServiceTests.cs
+++ b/octo-fiesta.Tests/YandexMetadataServiceTests.cs
@@ -343,7 +343,6 @@ public class YandexMetadataServiceTests
         Assert.Equal("Rock Forever!", result[0].Album); // Album should be playlist name
         Assert.Equal("pl-yandex-f3063016-5636-454e-916e-00a756e9b25d", result[0].AlbumId);
         Assert.Equal(1, result[0].Track); // Track index starts at 1
-        Assert.Equal("ext-yandex-song-100001:1000011", result[0].Id);
         Assert.Equal("yandex", result[0].ExternalProvider);
         Assert.Equal("100001:1000011", result[0].ExternalId);
         
@@ -352,7 +351,6 @@ public class YandexMetadataServiceTests
         Assert.Equal("Panic! At The Disco", result[1].Artist);
         Assert.Equal("Rock Forever!", result[1].Album); // Album should be playlist name
         Assert.Equal(2, result[1].Track); // Track index increments
-        Assert.Equal("ext-yandex-song-300003:3000033", result[1].Id);
     }
     
     [Fact]

--- a/octo-fiesta/Models/Domain/Song.cs
+++ b/octo-fiesta/Models/Domain/Song.cs
@@ -4,13 +4,7 @@ namespace octo_fiesta.Models.Domain;
 /// Represents a song (local or external)
 /// </summary>
 public class Song
-{
-    /// <summary>
-    /// Unique ID. For external songs, prefixed with "ext-" + provider + "-" + external id
-    /// Example: "ext-deezer-123456" or "local-789"
-    /// </summary>
-    public string Id { get; set; } = string.Empty;
-    
+{    
     public string Title { get; set; } = string.Empty;
     public string Artist { get; set; } = string.Empty;
     public string? ArtistId { get; set; }

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -364,7 +364,6 @@ public class DeezerMetadataService : IMusicMetadataService
         
         return new Song
         {
-            Id = $"ext-deezer-song-{externalId}",
             Title = track.GetProperty("title").GetString() ?? "",
             Artist = mainArtist,
             Artists = !string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>(),
@@ -498,7 +497,6 @@ public class DeezerMetadataService : IMusicMetadataService
         
         return new Song
         {
-            Id = $"ext-deezer-song-{externalId}",
             Title = track.GetProperty("title").GetString() ?? "",
             Artist = mainArtist,
             Artists = contributors.Count > 0 ? contributors : (!string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>()),

--- a/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
@@ -567,7 +567,6 @@ public class QobuzMetadataService : IMusicMetadataService
         
         return new Song
         {
-            Id = $"ext-qobuz-song-{externalId}",
             Title = title,
             Artist = performerName,
             Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -814,7 +814,6 @@ public class SquidWTFMetadataService : IMusicMetadataService
         
         return new Song
         {
-            Id = $"ext-squidwtf-song-{externalId}",
             Title = track.Title ?? "",
             Artist = performerName,
             Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),
@@ -919,7 +918,6 @@ public class SquidWTFMetadataService : IMusicMetadataService
 
         return new Song
         {
-            Id = $"ext-squidwtf-song-{externalId}",
             Title = title,
             Artist = mainArtistName,
             Artists = artistNames,
@@ -975,7 +973,6 @@ public class SquidWTFMetadataService : IMusicMetadataService
         
         return new Song
         {
-            Id = $"ext-squidwtf-song-{externalId}",
             Title = track.Title ?? "",
             Artist = mainArtistName,
             Artists = artistNames,

--- a/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
+++ b/octo-fiesta/Services/Subsonic/PlaylistSyncService.cs
@@ -269,7 +269,7 @@ public class PlaylistSyncService
         // Skip real-time updates during full playlist download (M3U will be created once at the end)
         if (isFullPlaylistDownload)
         {
-            _logger.LogDebug("Skipping M3U update for track {TrackId} (full playlist download in progress)", track.Id);
+            _logger.LogDebug("Skipping M3U update for track ext-{Provider}-song-{TrackId} (full playlist download in progress)", track.ExternalProvider, track.ExternalId);
             return;
         }
         
@@ -321,7 +321,7 @@ public class PlaylistSyncService
                 string? trackLocalPath = null;
                 
                 // If this is the track we just downloaded
-                if (playlistTrack.Id == track.Id)
+                if (playlistTrack.ExternalId == track.ExternalId)
                 {
                     trackLocalPath = localPath;
                 }

--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -322,9 +322,11 @@ public class SubsonicResponseBuilder
             size = (long)bitRate * 125L * (long)(song.Duration ?? 0);
         }
 
+        string songId = $"ext-{song.ExternalProvider}-song-{song.ExternalId}";
+
         var result = new Dictionary<string, object>
         {
-            ["id"] = song.Id,
+            ["id"] = songId,
             ["parent"] = song.AlbumId ?? "",
             ["isDir"] = false,
             ["title"] = song.Title,
@@ -351,7 +353,7 @@ public class SubsonicResponseBuilder
         // Only include coverArt if the song has a cover URL (avoids broken images for songs without covers)
         if (song.IsLocal || !string.IsNullOrEmpty(song.CoverArtUrl))
         {
-            result["coverArt"] = song.Id;
+            result["coverArt"] = songId;
         }
 
         if (created != null)
@@ -455,8 +457,10 @@ public class SubsonicResponseBuilder
             size = (long)bitRate * 125L * duration;
         }
 
+        string songId = $"ext-{song.ExternalProvider}-song-{song.ExternalId}";
+
         var songElement = new XElement(ns + "song",
-            new XAttribute("id", song.Id),
+            new XAttribute("id", songId),
             new XAttribute("title", song.Title),
             new XAttribute("album", song.Album ?? ""),
             new XAttribute("albumId", albumId),
@@ -482,7 +486,7 @@ public class SubsonicResponseBuilder
         // Only include coverArt if the song has a cover URL (avoids broken images for songs without covers)
         if (song.IsLocal || !string.IsNullOrEmpty(song.CoverArtUrl))
         {
-            songElement.Add(new XAttribute("coverArt", song.Id));
+            songElement.Add(new XAttribute("coverArt", songId));
         }
 
         if (!string.IsNullOrEmpty(song.ArtistId))

--- a/octo-fiesta/Services/Yandex/YandexMetadataService.cs
+++ b/octo-fiesta/Services/Yandex/YandexMetadataService.cs
@@ -21,7 +21,6 @@ public class YandexMetadataService : IMusicMetadataService
     private readonly bool _includeUnavailable;
     private const string BaseUrl = "https://api.music.yandex.net";
     private const string ProviderName = "yandex";
-    private const string SongPrefix = "ext-yandex-song-";
     private const string AlbumPrefix = "ext-yandex-album-";
     private const string ArtistPrefix = "ext-yandex-artist-";
 
@@ -320,7 +319,6 @@ public class YandexMetadataService : IMusicMetadataService
 
         return new Song
         {
-            Id = SongPrefix + externalTrackId,
             Title = yandexTrack.Title ?? string.Empty,
             Artist = yandexArtist?.Name ?? string.Empty,
             ArtistId = string.IsNullOrEmpty(externalArtistId) ? null : ArtistPrefix + externalArtistId,


### PR DESCRIPTION
Song.Id duplicated ExternalProvider + ExternalId. Field is dropped; SubsonicResponseBuilder now builds "ext-{provider}-song-{externalId}" on demand. PlaylistSyncService compares by ExternalId. Provider parsers stop writing Song.Id. Wire format unchanged.