### PR TITLE
Parallel to #257. Replaces XmlSerializer with XDocument-based parsing

### DIFF
--- a/octo-fiesta.Tests/YandexDownloadServiceTests.cs
+++ b/octo-fiesta.Tests/YandexDownloadServiceTests.cs
@@ -99,6 +99,82 @@ public class YandexDownloadServiceTests : IDisposable
             _loggerMock.Object);
     }
 
+    private void SetupLegacyApiScenario(string legacyDownloadInfoXml)
+    {
+        _metadataServiceMock
+            .Setup(s => s.GetSongAsync("yandex", "123456"))
+            .ReturnsAsync(new Song
+            {
+                Title = "Test Song",
+                IsLocal = false,
+                ExternalProvider = "yandex",
+                ExternalId = "123456"
+            });
+
+        // Modern API errors out -> triggers legacy fallback
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/get-file-info/")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("""
+                {
+                    "result": {
+                        "name": "track-download-info-error",
+                        "message": "no-rights"
+                    }
+                }
+                """)
+            });
+
+        // Legacy options endpoint
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/download-info")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("""
+                {
+                    "result": [{
+                        "codec": "mp3",
+                        "downloadInfoUrl": "https://example.org/get-mp3",
+                        "bitrateInKbps": 128
+                    }]
+                }
+                """)
+            });
+
+        // The variable part — the XML response that our XDocument parser handles
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("https://example.org/get-mp3")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(legacyDownloadInfoXml)
+            });
+
+        // Actual track download (only hit if legacy parsing succeeds)
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("get-example-file.org")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("test-song-content")
+            });
+    }
+
     #region IsAvailableAsync Tests
 
     [Fact]
@@ -261,103 +337,14 @@ public class YandexDownloadServiceTests : IDisposable
     [Fact]
     public async Task DownloadSongAsync_WhenModernApiErrors_DownloadsFromLegacyApi()
     {
-        // Arrange
-
-        _metadataServiceMock
-            .Setup(s => s.GetSongAsync("yandex", "123456"))
-            .ReturnsAsync(new Song
-            {
-                Title = "Test Song",
-                Artist = "Test Artist",
-                ArtistId = "ext-yandex-artist-123456",
-                Album = "Test Album",
-                AlbumId = "ext-yandex-album-123456",
-                Duration = 15,
-                IsLocal = false,
-                ExternalProvider = "yandex",
-                ExternalId = "123456"
-            });
-
-        var mockResponseModernApi = new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent("""
-            {
-                "result": {
-                    "name": "track-download-info-error",
-                    "message": "no-rights"
-                }
-            }
-            """)
-        };
-
-        _httpMessageHandlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/get-file-info/")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(mockResponseModernApi);
-
-
-        var mockResponseLegacyApi = new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent("""
-            {
-                "result": [
-                    {
-                        "codec": "mp3",
-                        "downloadInfoUrl": "https://example.org/get-mp3",
-                        "bitrateInKbps": 128
-                    }
-                ]
-            }
-            """)
-        };
-
-        _httpMessageHandlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/download-info")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(mockResponseLegacyApi);
-        
-        var mockResponseLegacyDownloadInfo = new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent("""
-            <download-info>
-                <host>get-example-file.org</host>
-                <path>/tes-test
-            </path>
-                <ts>19cde9597e0</ts>
-                <s>abracadabra</s>
-            </download-info>
-            """)
-        };
-
-        _httpMessageHandlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("https://example.org/get-mp3")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(mockResponseLegacyDownloadInfo);
-        
-        string testSongContent = "test-song-content";
-        var mockResponseLegacyDownloadTrack = new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent(testSongContent)
-        };
-
-        _httpMessageHandlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("get-example-file.org")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(mockResponseLegacyDownloadTrack);
-
-
+        SetupLegacyApiScenario("""
+        <download-info>
+            <host>get-example-file.org</host>
+            <path>/tes-test</path>
+            <ts>19cde9597e0</ts>
+            <s>abracadabra</s>
+        </download-info>
+        """);
 
         var service = CreateService(oAuthToken: "test-token");
 
@@ -366,7 +353,40 @@ public class YandexDownloadServiceTests : IDisposable
         string result = File.ReadAllText(resultPath);
 
         // Assert
-        Assert.Equal(testSongContent, result);
+        Assert.Equal("test-song-content", result);
+    }
+
+    [Fact]
+    public async Task DownloadSongAsync_WhenLegacyXmlMissingRequiredField_ThrowsDownloadFailedException()
+    {
+        SetupLegacyApiScenario("""
+        <download-info>
+            <path>/tes-test</path>
+            <ts>19cde9597e0</ts>
+            <s>abracadabra</s>
+        </download-info>
+        """);
+
+        var service = CreateService(oAuthToken: "test-token");
+        await Assert.ThrowsAsync<Exception>(() => service.DownloadSongAsync("yandex", "123456"));
+    }
+
+    [Fact]
+    public async Task DownloadSongAsync_WhenLegacyXmlIsMalformed_ThrowsDownloadFailedException()
+    {
+        SetupLegacyApiScenario("not xml at all");
+
+        var service = CreateService(oAuthToken: "test-token");
+        await Assert.ThrowsAsync<Exception>(() => service.DownloadSongAsync("yandex", "123456"));
+    }
+
+    [Fact]
+    public async Task DownloadSongAsync_WhenLegacyXmlIsEmpty_ThrowsDownloadFailedException()
+    {
+        SetupLegacyApiScenario("");
+
+        var service = CreateService(oAuthToken: "test-token");
+        await Assert.ThrowsAsync<Exception>(() => service.DownloadSongAsync("yandex", "123456"));
     }
 
     [Fact]

--- a/octo-fiesta/Models/Yandex/YandexApiResponses.cs
+++ b/octo-fiesta/Models/Yandex/YandexApiResponses.cs
@@ -1,7 +1,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Xml.Serialization;
 
 namespace octo_fiesta.Models.Yandex;
 
@@ -500,17 +499,12 @@ public class YandexDownloadOptionLegacy
 /// Obtained from an URL provided by YandexTrackDownloadOptionLegacy
 /// This is used in legacy method of downloading
 /// </summary>
-[XmlRoot("download-info")]
-public class YandexDownloadInfoLegacy
+public record YandexDownloadInfoLegacy
 {
-    [XmlElement("host")]
-    public required string Host { get; set; }
-    [XmlElement("path")]
-    public required string Path { get; set; }
-    [XmlElement("ts")]
-    public required string Ts { get; set; }
-    [XmlElement("s")]
-    public required string S { get; set; }
+    public required string Host { get; init; }
+    public required string Path { get; init; }
+    public required string Ts { get; init; }
+    public required string S { get; init; }
 }
 
 public class YandexUserAccountStatus

--- a/octo-fiesta/Services/Yandex/YandexDownloadService.cs
+++ b/octo-fiesta/Services/Yandex/YandexDownloadService.cs
@@ -4,7 +4,6 @@ using octo_fiesta.Services.Local;
 using octo_fiesta.Models.Settings;
 using Microsoft.Extensions.Options;
 using octo_fiesta.Models.Yandex;
-using System.Xml.Serialization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -14,6 +13,8 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.IO;
+using System.Xml.Linq;
+using System.Xml;
 
 namespace octo_fiesta.Services.Yandex;
 
@@ -359,15 +360,36 @@ public class YandexDownloadService : BaseDownloadService
         }
 
         string downloadInfoResponseString = await downloadInfoResponse.Content.ReadAsStringAsync(cancellationToken);
-        var xmlSerializer = new XmlSerializer(typeof(YandexDownloadInfoLegacy));
-        using var reader = new StringReader(downloadInfoResponseString);
-        var downloadInfo = (YandexDownloadInfoLegacy?)xmlSerializer.Deserialize(reader);
-        if (downloadInfo is null)
+        XDocument doc;
+        try
         {
-            _logger.LogWarning("Failed to deserialize Yandex API response for track download info request.");
+            doc = XDocument.Parse(downloadInfoResponseString);
+        }
+        catch (XmlException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse Yandex API XML response for track download info request.");
             return null;
-        };
+        }
 
+        var root = doc.Root;
+        var host = root?.Element("host")?.Value;
+        var path = root?.Element("path")?.Value;
+        var ts = root?.Element("ts")?.Value;
+        var s = root?.Element("s")?.Value;
+
+        if (host is null || path is null || ts is null || s is null)
+        {
+            _logger.LogWarning("Yandex API XML response missing required field for track download info request");
+            return null;
+        }
+
+        var downloadInfo = new YandexDownloadInfoLegacy
+        {
+            Host = host,
+            Path = path,
+            Ts = ts,
+            S = s
+        };
 
         // Prepare signed download URL
         string stringToSign = MD_SIGNING_SALT + downloadInfo.Path[1..] + downloadInfo.S;


### PR DESCRIPTION
refactor(yandex): parse legacy download-info XML with XDocument

Replace XmlSerializer with XDocument-based parsing in
YandexDownloadService.GetDirectDownloadUrlLegacyAsync. The new parser
extracts the four required elements explicitly, null-checks them
before constructing YandexDownloadInfoLegacy via object initializer,
and only catches XmlException so unrelated exceptions propagate as
before. Missing or malformed responses now fail with a clear log
message instead of XmlSerializer's mixed throw/silent-null behaviour.

YandexDownloadInfoLegacy is now a record with init-only properties.
The `required` keyword is enforced at construction time instead of
being silently bypassed by XmlSerializer's setter-based deserialisation
path.

Three new tests cover the failure pathways (missing required field,
malformed XML, empty response), backed by a SetupLegacyApiScenario
helper that consolidates the previously duplicated mock setup.

Parallel to #257. The two PRs touch different parts of
YandexApiResponses.cs (#257 converts the other 27 DTOs, this one
converts only YandexDownloadInfoLegacy and removes the now-unused
System.Xml.Serialization using).