### PR TITLE
Fix multiple artists in Subsonic responses (#222)

### DIFF
--- a/octo-fiesta.Tests/MultiArtistMatrixTests.cs
+++ b/octo-fiesta.Tests/MultiArtistMatrixTests.cs
@@ -1,0 +1,332 @@
+using octo_fiesta.Models.Domain;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Models.Subsonic;
+using octo_fiesta.Services.Deezer;
+using octo_fiesta.Services.Qobuz;
+using octo_fiesta.Services.SquidWTF;
+using octo_fiesta.Services.Subsonic;
+using octo_fiesta.Services.Yandex;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Xml.Linq;
+
+namespace octo_fiesta.Tests;
+
+/// <summary>
+/// Matrix coverage for the multi-artist fix (#222).
+///
+/// Two dimensions:
+///   1. Each provider must populate <see cref="Song.Artists"/> with identified
+///      artists (id + name), exposing multiple where the source has them.
+///   2. The Subsonic serializer must emit those artists (OpenSubsonic `artists`
+///      array in JSON, repeated &lt;artists&gt; elements in XML) so clients display them.
+///
+/// The git history of this file shows the pre-fix form, where every test instead
+/// asserted the broken state (no `artists` output) and passed on the unfixed code.
+/// </summary>
+public class MultiArtistMatrixTests
+{
+    private readonly SubsonicResponseBuilder _builder = new();
+    private static readonly XNamespace Ns = "http://subsonic.org/restapi";
+
+    // ---- infrastructure helpers ----
+
+    private static IHttpClientFactory Factory(HttpMessageHandler handler)
+    {
+        var f = new Mock<IHttpClientFactory>();
+        f.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler) { BaseAddress = new Uri("https://example.org") });
+        return f.Object;
+    }
+
+    /// <summary>A handler that returns the same JSON body (fresh instance) for every request.</summary>
+    private static HttpMessageHandler JsonHandler(string json)
+    {
+        var h = new Mock<HttpMessageHandler>();
+        h.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json)
+            });
+        return h.Object;
+    }
+
+    private List<(string id, string name)> JsonArtists(Song song)
+    {
+        var json = _builder.ConvertSongToJson(song);
+        Assert.True(json.ContainsKey("artists"), "Subsonic JSON is missing the `artists` array");
+        var list = Assert.IsType<List<Dictionary<string, object>>>(json["artists"]);
+        return list.Select(d => ((string)d["id"], (string)d["name"])).ToList();
+    }
+
+    private List<(string id, string name)> XmlArtists(Song song)
+    {
+        var el = _builder.ConvertSongToXml(song, Ns);
+        return el.Elements(Ns + "artists")
+            .Select(e => (e.Attribute("id")!.Value, e.Attribute("name")!.Value))
+            .ToList();
+    }
+
+    // ---- per-provider service builders ----
+
+    private static DeezerMetadataService Deezer(string json) =>
+        new(Factory(JsonHandler(json)), Options.Create(new SubsonicSettings()));
+
+    private static QobuzMetadataService Qobuz(string json)
+    {
+        var factory = Factory(JsonHandler(json));
+        var bundleLogger = Mock.Of<ILogger<QobuzBundleService>>();
+        var bundle = new Mock<QobuzBundleService>(factory, bundleLogger) { CallBase = false };
+        bundle.Setup(b => b.GetAppIdAsync()).ReturnsAsync("fake-app-id");
+        bundle.Setup(b => b.GetSecretsAsync()).ReturnsAsync(new List<string> { "fake-secret" });
+        bundle.Setup(b => b.GetSecretAsync(It.IsAny<int>())).ReturnsAsync("fake-secret");
+        return new QobuzMetadataService(
+            factory,
+            Options.Create(new SubsonicSettings()),
+            Options.Create(new QobuzSettings { UserAuthToken = "tok", UserId = "1" }),
+            bundle.Object,
+            Mock.Of<ILogger<QobuzMetadataService>>());
+    }
+
+    private static YandexMetadataService Yandex(string json)
+    {
+        var factory = Factory(JsonHandler(json));
+        return new YandexMetadataService(
+            factory,
+            Options.Create(new YandexSettings { OAuthToken = "tok", Quality = "AAC_256", Language = "ru" }),
+            Mock.Of<ILogger<YandexMetadataService>>());
+    }
+
+    private static SquidWTFMetadataService SquidWtfTidal(string json)
+    {
+        var factory = Factory(JsonHandler(json));
+        var settings = Options.Create(new SquidWTFSettings
+        {
+            Source = "Tidal",
+            Instances = new List<string> { "https://inst1.test" }
+        });
+        var instanceManager = new SquidWTFInstanceManager(
+            factory, settings, Mock.Of<ILogger<SquidWTFInstanceManager>>());
+        return new SquidWTFMetadataService(
+            factory,
+            settings,
+            Options.Create(new SubsonicSettings()),
+            instanceManager,
+            Mock.Of<ILogger<SquidWTFMetadataService>>());
+    }
+
+    // ---- fixtures (multi-artist payloads) ----
+
+    private const string DeezerTrackJson = """
+    {
+      "id": 123,
+      "title": "Deezer Multi",
+      "duration": 210,
+      "artist": { "id": 7, "name": "Deezer Main" },
+      "album": { "id": 70, "title": "Deezer Album", "artist": { "id": 7, "name": "Deezer Main" } },
+      "contributors": [
+        { "id": 7, "name": "Deezer Main", "role": "Main" },
+        { "id": 8, "name": "Deezer Feat", "role": "Featured" }
+      ]
+    }
+    """;
+
+    private const string QobuzTrackJson = """
+    {
+      "id": 123456789,
+      "title": "Take Five",
+      "duration": 324,
+      "track_number": 1,
+      "performer": { "id": 111, "name": "Dave Brubeck Quartet" },
+      "album": { "id": 222, "title": "Time Out", "artist": { "id": 111, "name": "Dave Brubeck Quartet" } }
+    }
+    """;
+
+    private const string YandexTrackJson = """
+    {
+      "result": [
+        {
+          "id": "88633197",
+          "title": "ABC",
+          "durationMs": 224630,
+          "artists": [
+            { "id": 8624246, "name": "Otica" },
+            { "id": 12756620, "name": "David Diesel" },
+            { "id": 1062258, "name": "Halogen" }
+          ],
+          "albums": [
+            {
+              "id": 17743572,
+              "title": "ATL",
+              "year": 2021,
+              "releaseDate": "2021-09-10T00:00:00+03:00",
+              "trackCount": 1,
+              "artists": [ { "id": 8624246, "name": "Otica" } ],
+              "trackPosition": { "volume": 1, "index": 1 }
+            }
+          ],
+          "coverUri": "get-image.example.org/path/%%%%"
+        }
+      ]
+    }
+    """;
+
+    private const string TidalTrackJson = """
+    {
+      "version": "1",
+      "data": {
+        "id": 555,
+        "title": "Tidal Multi",
+        "duration": 200,
+        "trackNumber": 1,
+        "volumeNumber": 1,
+        "explicit": false,
+        "artist": { "id": 10, "name": "Tidal Main" },
+        "artists": [
+          { "id": 10, "name": "Tidal Main" },
+          { "id": 11, "name": "Tidal Feat" }
+        ],
+        "album": { "id": 99, "title": "Tidal Album", "releaseDate": "2020-01-01" }
+      }
+    }
+    """;
+
+    private static Task<Song?> DeezerSong() => Deezer(DeezerTrackJson).GetSongAsync("deezer", "123");
+    private static Task<Song?> QobuzSong() => Qobuz(QobuzTrackJson).GetSongAsync("qobuz", "123456789");
+    private static Task<Song?> YandexSong() => Yandex(YandexTrackJson).GetSongAsync("yandex", "88633197:17743572");
+    private static Task<Song?> TidalSong() => SquidWtfTidal(TidalTrackJson).GetSongAsync("squidwtf", "555");
+
+    // =====================================================================
+    // Provider dimension: Song.Artists is populated with id + name
+    // =====================================================================
+
+    [Fact]
+    public async Task Deezer_PopulatesMultipleIdentifiedArtists()
+    {
+        var song = await DeezerSong();
+        Assert.NotNull(song);
+        Assert.Equal(
+            new[] { ("ext-deezer-artist-7", "Deezer Main"), ("ext-deezer-artist-8", "Deezer Feat") },
+            song!.Artists.Select(a => (a.Id, a.Name)));
+    }
+
+    [Fact]
+    public async Task Qobuz_PopulatesIdentifiedArtist()
+    {
+        var song = await QobuzSong();
+        Assert.NotNull(song);
+        Assert.Equal(
+            new[] { ("ext-qobuz-artist-111", "Dave Brubeck Quartet") },
+            song!.Artists.Select(a => (a.Id, a.Name)));
+    }
+
+    [Fact]
+    public async Task Yandex_PopulatesMultipleIdentifiedArtists()
+    {
+        var song = await YandexSong();
+        Assert.NotNull(song);
+        Assert.Equal(
+            new[]
+            {
+                ("ext-yandex-artist-8624246", "Otica"),
+                ("ext-yandex-artist-12756620", "David Diesel"),
+                ("ext-yandex-artist-1062258", "Halogen"),
+            },
+            song!.Artists.Select(a => (a.Id, a.Name)));
+    }
+
+    [Fact]
+    public async Task Tidal_PopulatesMultipleIdentifiedArtists()
+    {
+        var song = await TidalSong();
+        Assert.NotNull(song);
+        Assert.Equal(
+            new[] { ("ext-squidwtf-artist-10", "Tidal Main"), ("ext-squidwtf-artist-11", "Tidal Feat") },
+            song!.Artists.Select(a => (a.Id, a.Name)));
+    }
+
+    // =====================================================================
+    // Serializer dimension: artists reach the client (JSON + XML), per provider
+    // =====================================================================
+
+    [Fact]
+    public async Task Deezer_Subsonic_EmitsArtists()
+    {
+        var song = (await DeezerSong())!;
+        var expected = new[] { ("ext-deezer-artist-7", "Deezer Main"), ("ext-deezer-artist-8", "Deezer Feat") };
+        Assert.Equal(expected, JsonArtists(song));
+        Assert.Equal(expected, XmlArtists(song));
+    }
+
+    [Fact]
+    public async Task Qobuz_Subsonic_EmitsArtists()
+    {
+        var song = (await QobuzSong())!;
+        var expected = new[] { ("ext-qobuz-artist-111", "Dave Brubeck Quartet") };
+        Assert.Equal(expected, JsonArtists(song));
+        Assert.Equal(expected, XmlArtists(song));
+    }
+
+    [Fact]
+    public async Task Yandex_Subsonic_EmitsArtists()
+    {
+        var song = (await YandexSong())!;
+        var expected = new[]
+        {
+            ("ext-yandex-artist-8624246", "Otica"),
+            ("ext-yandex-artist-12756620", "David Diesel"),
+            ("ext-yandex-artist-1062258", "Halogen"),
+        };
+        Assert.Equal(expected, JsonArtists(song));
+        Assert.Equal(expected, XmlArtists(song));
+    }
+
+    [Fact]
+    public async Task Tidal_Subsonic_EmitsArtists()
+    {
+        var song = (await TidalSong())!;
+        var expected = new[] { ("ext-squidwtf-artist-10", "Tidal Main"), ("ext-squidwtf-artist-11", "Tidal Feat") };
+        Assert.Equal(expected, JsonArtists(song));
+        Assert.Equal(expected, XmlArtists(song));
+    }
+
+    // =====================================================================
+    // Serializer edge cases
+    // =====================================================================
+
+    [Fact]
+    public void Subsonic_EmptyArtists_ProducesEmptyArtistsCollection()
+    {
+        var song = new Song { Title = "T", Artist = "Main", ExternalProvider = "deezer", ExternalId = "1" };
+        Assert.Empty(JsonArtists(song));
+        Assert.Empty(XmlArtists(song));
+    }
+
+    [Fact]
+    public void Subsonic_HandBuiltMultiArtist_RoundTripsIdAndName()
+    {
+        var song = new Song
+        {
+            Title = "T",
+            Artist = "A",
+            ExternalProvider = "deezer",
+            ExternalId = "1",
+            Artists = new List<Artist>
+            {
+                new() { Id = "ext-deezer-artist-1", Name = "A" },
+                new() { Id = "ext-deezer-artist-2", Name = "B" },
+            }
+        };
+        var expected = new[] { ("ext-deezer-artist-1", "A"), ("ext-deezer-artist-2", "B") };
+        Assert.Equal(expected, JsonArtists(song));
+        Assert.Equal(expected, XmlArtists(song));
+    }
+}

--- a/octo-fiesta/Models/Domain/Song.cs
+++ b/octo-fiesta/Models/Domain/Song.cs
@@ -59,10 +59,11 @@ public class Song
     public string? Copyright { get; set; }
     
     /// <summary>
-    /// All performing artists (for multi-artist tracks).
-    /// First entry should match Artist. Used for file tagging (Performers field).
+    /// All performing artists (for multi-artist tracks), with id + name so clients
+    /// can link each one. First entry should match Artist. Used for file tagging
+    /// (Performers field) and the OpenSubsonic `artists` field.
     /// </summary>
-    public List<string> Artists { get; set; } = new();
+    public List<Artist> Artists { get; set; } = new();
     
     /// <summary>
     /// Contributing artists (features, etc.)

--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -793,8 +793,8 @@ public abstract class BaseDownloadService : IDownloadService
 
             // Basic metadata
             tagFile.Tag.Title = song.Title;
-            tagFile.Tag.Performers = song.Artists.Count > 0 
-                ? song.Artists.ToArray() 
+            tagFile.Tag.Performers = song.Artists.Count > 0
+                ? song.Artists.Select(a => a.Name).ToArray()
                 : new[] { song.Artist };
             tagFile.Tag.Album = song.Album;
             tagFile.Tag.AlbumArtists = new[] { !string.IsNullOrEmpty(song.AlbumArtist) ? song.AlbumArtist : song.Artist };

--- a/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerMetadataService.cs
@@ -389,21 +389,23 @@ public class DeezerMetadataService : IMusicMetadataService
         {
             Title = track.GetProperty("title").GetString() ?? "",
             Artist = mainArtist,
-            Artists = !string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>(),
-            ArtistId = track.TryGetProperty("artist", out var artistForId) 
-                ? $"ext-deezer-artist-{artistForId.GetProperty("id").GetInt64()}" 
+            Artists = track.TryGetProperty("artist", out var artistForList)
+                ? new List<Artist> { ParseDeezerArtist(artistForList) }
+                : new List<Artist>(),
+            ArtistId = track.TryGetProperty("artist", out var artistForId)
+                ? $"ext-deezer-artist-{artistForId.GetProperty("id").GetInt64()}"
                 : null,
-            Album = track.TryGetProperty("album", out var album) 
-                ? album.GetProperty("title").GetString() ?? "" 
+            Album = track.TryGetProperty("album", out var album)
+                ? album.GetProperty("title").GetString() ?? ""
                 : "",
-            AlbumId = track.TryGetProperty("album", out var albumForId) 
-                ? $"ext-deezer-album-{albumForId.GetProperty("id").GetInt64()}" 
+            AlbumId = track.TryGetProperty("album", out var albumForId)
+                ? $"ext-deezer-album-{albumForId.GetProperty("id").GetInt64()}"
                 : null,
-            Duration = track.TryGetProperty("duration", out var duration) 
-                ? duration.GetInt32() 
+            Duration = track.TryGetProperty("duration", out var duration)
+                ? duration.GetInt32()
                 : null,
             Track = trackNumber,
-            CoverArtUrl = track.TryGetProperty("album", out var albumForCover) && 
+            CoverArtUrl = track.TryGetProperty("album", out var albumForCover) &&
                           albumForCover.TryGetProperty("cover_medium", out var cover)
                 ? cover.GetString()
                 : null,
@@ -471,8 +473,10 @@ public class DeezerMetadataService : IMusicMetadataService
             }
         }
         
-        // Contributors
+        // Contributors. Deezer lists all performing artists here (with their ids),
+        // so we use them both for the Contributors names and the typed Artists list.
         var contributors = new List<string>();
+        var contributorArtists = new List<Artist>();
         if (track.TryGetProperty("contributors", out var contribs))
         {
             foreach (var contrib in contribs.EnumerateArray())
@@ -481,7 +485,10 @@ public class DeezerMetadataService : IMusicMetadataService
                 {
                     var name = contribName.GetString();
                     if (!string.IsNullOrEmpty(name))
+                    {
                         contributors.Add(name);
+                        contributorArtists.Add(ParseDeezerArtist(contrib));
+                    }
                 }
             }
         }
@@ -522,8 +529,12 @@ public class DeezerMetadataService : IMusicMetadataService
         {
             Title = track.GetProperty("title").GetString() ?? "",
             Artist = mainArtist,
-            Artists = contributors.Count > 0 ? contributors : (!string.IsNullOrEmpty(mainArtist) ? new List<string> { mainArtist } : new List<string>()),
-            ArtistId = track.TryGetProperty("artist", out var artistForId) 
+            Artists = contributorArtists.Count > 0
+                ? contributorArtists
+                : (track.TryGetProperty("artist", out var mainArtistForList)
+                    ? new List<Artist> { ParseDeezerArtist(mainArtistForList) }
+                    : new List<Artist>()),
+            ArtistId = track.TryGetProperty("artist", out var artistForId)
                 ? $"ext-deezer-artist-{artistForId.GetProperty("id").GetInt64()}" 
                 : null,
             Album = track.TryGetProperty("album", out var album) 

--- a/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
+++ b/octo-fiesta/Services/Qobuz/QobuzMetadataService.cs
@@ -550,7 +550,12 @@ public class QobuzMetadataService : IMusicMetadataService
         var performerName = track.TryGetProperty("performer", out var performer)
             ? performer.GetProperty("name").GetString() ?? ""
             : "";
-        
+
+        var performerRawId = track.TryGetProperty("performer", out var performerForId)
+            ? GetIdAsString(performerForId.GetProperty("id"))
+            : null;
+        var performerArtistId = performerRawId != null ? $"ext-qobuz-artist-{performerRawId}" : null;
+
         var albumTitle = track.TryGetProperty("album", out var album)
             ? album.GetProperty("title").GetString() ?? ""
             : "";
@@ -569,10 +574,10 @@ public class QobuzMetadataService : IMusicMetadataService
         {
             Title = title,
             Artist = performerName,
-            Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),
-            ArtistId = track.TryGetProperty("performer", out var performerForId)
-                ? $"ext-qobuz-artist-{GetIdAsString(performerForId.GetProperty("id"))}"
-                : null,
+            Artists = !string.IsNullOrEmpty(performerName)
+                ? new List<Artist> { new Artist { Id = performerArtistId ?? "", Name = performerName, IsLocal = false, ExternalProvider = "qobuz", ExternalId = performerRawId } }
+                : new List<Artist>(),
+            ArtistId = performerArtistId,
             Album = albumTitle,
             AlbumId = albumId,
             AlbumArtist = albumArtist,

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -811,13 +811,16 @@ public class SquidWTFMetadataService : IMusicMetadataService
         }
         
         var performerName = track.Performer?.Name ?? "";
-        
+        var performerArtistId = track.Performer != null ? $"ext-squidwtf-artist-{track.Performer.Id}" : null;
+
         return new Song
         {
             Title = track.Title ?? "",
             Artist = performerName,
-            Artists = !string.IsNullOrEmpty(performerName) ? new List<string> { performerName } : new List<string>(),
-            ArtistId = track.Performer != null ? $"ext-squidwtf-artist-{track.Performer.Id}" : null,
+            Artists = !string.IsNullOrEmpty(performerName)
+                ? new List<Artist> { new Artist { Id = performerArtistId ?? "", Name = performerName, IsLocal = false, ExternalProvider = "squidwtf", ExternalId = track.Performer?.Id.ToString() } }
+                : new List<Artist>(),
+            ArtistId = performerArtistId,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,
@@ -901,16 +904,16 @@ public class SquidWTFMetadataService : IMusicMetadataService
             }
         }
         
-        var artistNames = track.Artists?
+        var artists = track.Artists?
             .Where(a => !string.IsNullOrEmpty(a.Name))
-            .Select(a => a.Name!)
-            .ToList() ?? new List<string>();
-        
-        var mainArtistName = track.Artist?.Name ?? (artistNames.FirstOrDefault() ?? "");
-        
-        // Ensure main artist is first in the list
-        if (artistNames.Count == 0 && !string.IsNullOrEmpty(mainArtistName))
-            artistNames.Add(mainArtistName);
+            .Select(MapTidalArtistToArtist)
+            .ToList() ?? new List<Artist>();
+
+        // Ensure main artist is present (first) when the artists array is empty
+        if (artists.Count == 0 && track.Artist != null && !string.IsNullOrEmpty(track.Artist.Name))
+            artists.Add(MapTidalArtistToArtist(track.Artist));
+
+        var mainArtistName = track.Artist?.Name ?? (artists.FirstOrDefault()?.Name ?? "");
 
         var title = track.Title ?? "";
         if (!string.IsNullOrEmpty(track.Version))
@@ -920,12 +923,10 @@ public class SquidWTFMetadataService : IMusicMetadataService
         {
             Title = title,
             Artist = mainArtistName,
-            Artists = artistNames,
-            ArtistId = track.Artist != null 
-                ? $"ext-squidwtf-artist-{track.Artist.Id}" 
-                : (track.Artists?.FirstOrDefault() is { } firstArtist 
-                    ? $"ext-squidwtf-artist-{firstArtist.Id}" 
-                    : null),
+            Artists = artists,
+            ArtistId = track.Artist != null
+                ? $"ext-squidwtf-artist-{track.Artist.Id}"
+                : artists.FirstOrDefault()?.Id,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,
@@ -960,27 +961,25 @@ public class SquidWTFMetadataService : IMusicMetadataService
             }
         }
         
-        var artistNames = track.Artists?
+        var artists = track.Artists?
             .Where(a => !string.IsNullOrEmpty(a.Name))
-            .Select(a => a.Name!)
-            .ToList() ?? new List<string>();
-        
-        var mainArtistName = track.Artist?.Name ?? (artistNames.FirstOrDefault() ?? "");
-        
-        // Ensure main artist is first in the list
-        if (artistNames.Count == 0 && !string.IsNullOrEmpty(mainArtistName))
-            artistNames.Add(mainArtistName);
-        
+            .Select(MapTidalArtistToArtist)
+            .ToList() ?? new List<Artist>();
+
+        // Ensure main artist is present (first) when the artists array is empty
+        if (artists.Count == 0 && track.Artist != null && !string.IsNullOrEmpty(track.Artist.Name))
+            artists.Add(MapTidalArtistToArtist(track.Artist));
+
+        var mainArtistName = track.Artist?.Name ?? (artists.FirstOrDefault()?.Name ?? "");
+
         return new Song
         {
             Title = track.Title ?? "",
             Artist = mainArtistName,
-            Artists = artistNames,
-            ArtistId = track.Artist != null 
-                ? $"ext-squidwtf-artist-{track.Artist.Id}" 
-                : (track.Artists?.FirstOrDefault() is { } firstTrackInfoArtist 
-                    ? $"ext-squidwtf-artist-{firstTrackInfoArtist.Id}" 
-                    : null),
+            Artists = artists,
+            ArtistId = track.Artist != null
+                ? $"ext-squidwtf-artist-{track.Artist.Id}"
+                : artists.FirstOrDefault()?.Id,
             Album = track.Album?.Title ?? "",
             AlbumId = track.Album != null ? $"ext-squidwtf-album-{track.Album.Id}" : null,
             Duration = track.Duration,

--- a/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo-fiesta/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -334,6 +334,11 @@ public class SubsonicResponseBuilder
             ["artist"] = song.Artist ?? "",
             ["albumId"] = song.AlbumId ?? "",
             ["artistId"] = song.ArtistId ?? "",
+            ["artists"] = song.Artists.Select(a => new Dictionary<string, object>
+            {
+                ["id"] = a.Id,
+                ["name"] = a.Name
+            }).ToList(),
             ["duration"] = song.Duration ?? 0,
             ["track"] = song.Track ?? 0,
             ["discNumber"] = song.DiscNumber ?? 0,
@@ -483,6 +488,14 @@ public class SubsonicResponseBuilder
             new XAttribute("displayAlbumArtist", song.Artist ?? ""),
             new XAttribute("displayComposer", "")
         );
+
+        // OpenSubsonic multi-artist support: one <artists> element per performing artist
+        foreach (var a in song.Artists)
+        {
+            songElement.Add(new XElement(ns + "artists",
+                new XAttribute("id", a.Id),
+                new XAttribute("name", a.Name)));
+        }
 
         // Only include coverArt if the song has a cover URL (avoids broken images for songs without covers)
         if (song.IsLocal || !string.IsNullOrEmpty(song.CoverArtUrl))

--- a/octo-fiesta/Services/Yandex/YandexMetadataService.cs
+++ b/octo-fiesta/Services/Yandex/YandexMetadataService.cs
@@ -349,7 +349,14 @@ public class YandexMetadataService : IMusicMetadataService
             AlbumArtist = yandexAlbum?.Artists.FirstOrDefault()?.Name,
             Composer = null,
             Label = yandexAlbum?.Labels?.FirstOrDefault()?.Name,
-            Artists = yandexTrack.Artists?.Select(a => a.Name)?.ToList() ?? [],
+            Artists = yandexTrack.Artists?.Select(a => new Artist
+            {
+                Id = ArtistPrefix + a.Id,
+                Name = a.Name,
+                IsLocal = false,
+                ExternalProvider = ProviderName,
+                ExternalId = a.Id.ToString()
+            }).ToList() ?? [],
             Contributors = [],
             IsLocal = false,
             ExternalProvider = ProviderName,


### PR DESCRIPTION
Fixes #222

Clients (Substreamer, Feishin, Supersonic) only showed a single artist because the Subsonic response never exposed the OpenSubsonic multi-artist field. ConvertSongToJson and ConvertSongToXml only emitted artist/displayArtist (one name).

The fix is minimal and scoped to this. Song.Artists changes from List<string> to List<Artist> so each artist carries an id and a name (linkable in the client). Each provider now populates Artists with identified artists: Deezer from the contributors array (all performing artists, with their ids), Qobuz from performer (typed with its id), SquidWTF/Tidal from the artists array (multiple) via MapTidalArtistToArtist, SquidWTF/Qobuz from performer, and Yandex from the artists array (multiple). SubsonicResponseBuilder now emits the OpenSubsonic artists field: an array of {id,name} in JSON and repeated <artists id name/> elements in XML. BaseDownloadService reads the Performers tag from Artists.Select(a => a.Name).

Contributors stays a List<string> since it is out of scope for this bug (it feeds the Composers tag).

Tests are matrix-based (MultiArtistMatrixTests), verified both before and after the fix. Before the fix, on unmodified dev, none of the 4 providers nor the serializer surfaced an artists array to the client, which all passed and confirmed the bug. After the fix, each provider produces the correct Artist{id,name} (multiple where the source has them) and the Subsonic output exposes them in both JSON and XML. The full suite is 549/549.