### PR TITLE
fix(squidwtf): fix Amazon Music API authentication flow

### DIFF
--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -793,8 +793,15 @@ public class SubsonicController : ControllerBase
                 {
                     try
                     {
-                        var token = await captchaSolver.GetAmazonCaptchaTokenAsync("https://amz.squid.wtf");
+                        var (token, sessionCookie) = await captchaSolver.GetAmazonCaptchaTokenAsync("https://amz.squid.wtf");
                         req.Headers.Add("X-Captcha-Token", token);
+                        req.Headers.Add("Cookie", sessionCookie);
+                        req.Headers.Add("Origin", "https://amz.squid.wtf");
+                        req.Headers.Add("Referer", "https://amz.squid.wtf/");
+                        req.Headers.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36");
+                        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+                        req.Headers.Add("Sec-Fetch-Mode", "cors");
+                        req.Headers.Add("Sec-Fetch-Dest", "empty");
                     }
                     catch (Exception ex)
                     {

--- a/octo-fiesta/Services/SquidWTF/SquidWTFCaptchaSolver.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFCaptchaSolver.cs
@@ -22,6 +22,7 @@ public class SquidWTFCaptchaSolver
 
     // Token-based captcha cache (Amazon Music uses X-Captcha-Token instead of a cookie)
     private string? _captchaToken;
+    private string? _amazonSessionCookie;   // amz_web_sess — must accompany every API request
     private DateTimeOffset _tokenExpiresAt = DateTimeOffset.MinValue;
     private static readonly TimeSpan TokenValidity = TimeSpan.FromMinutes(13);
     private readonly SemaphoreSlim _tokenLock = new(1, 1);
@@ -63,26 +64,26 @@ public class SquidWTFCaptchaSolver
     }
 
     /// <summary>
-    /// Returns an X-Captcha-Token value for Amazon Music (amz.squid.wtf).
-    /// Uses /api/captcha/challenge + /api/captcha/verify → { token }.
+    /// Returns (X-Captcha-Token, amz_web_sess cookie value) for Amazon Music (amz.squid.wtf).
+    /// Both values must be sent with every API request.
     /// </summary>
-    public async Task<string> GetAmazonCaptchaTokenAsync(
+    public async Task<(string Token, string SessionCookie)> GetAmazonCaptchaTokenAsync(
         string baseUrl,
         bool forceRefresh = false,
         CancellationToken cancellationToken = default)
     {
-        if (!forceRefresh && _captchaToken != null && DateTimeOffset.UtcNow < _tokenExpiresAt)
-            return _captchaToken;
+        if (!forceRefresh && _captchaToken != null && _amazonSessionCookie != null && DateTimeOffset.UtcNow < _tokenExpiresAt)
+            return (_captchaToken, _amazonSessionCookie);
 
         await _tokenLock.WaitAsync(cancellationToken);
         try
         {
-            if (!forceRefresh && _captchaToken != null && DateTimeOffset.UtcNow < _tokenExpiresAt)
-                return _captchaToken;
+            if (!forceRefresh && _captchaToken != null && _amazonSessionCookie != null && DateTimeOffset.UtcNow < _tokenExpiresAt)
+                return (_captchaToken, _amazonSessionCookie);
 
-            _captchaToken = await SolveAndVerifyAmazonAsync(baseUrl, cancellationToken);
+            (_captchaToken, _amazonSessionCookie) = await SolveAndVerifyAmazonAsync(baseUrl, cancellationToken);
             _tokenExpiresAt = DateTimeOffset.UtcNow + TokenValidity;
-            return _captchaToken;
+            return (_captchaToken, _amazonSessionCookie);
         }
         finally
         {
@@ -90,10 +91,20 @@ public class SquidWTFCaptchaSolver
         }
     }
 
-    private async Task<string> SolveAndVerifyAmazonAsync(string baseUrl, CancellationToken ct)
+    private async Task<(string Token, string SessionCookie)> SolveAndVerifyAmazonAsync(string baseUrl, CancellationToken ct)
     {
-        var http = _httpClientFactory.CreateClient();
+        // Use a dedicated client with its own CookieContainer so the amz_web_sess cookie
+        // set on the page load is forwarded to /api/captcha/challenge and /api/captcha/verify.
+        var cookieContainer = new System.Net.CookieContainer();
+        using var handler = new HttpClientHandler { CookieContainer = cookieContainer };
+        using var http = new HttpClient(handler, disposeHandler: false);
+
         var trimmed = baseUrl.TrimEnd('/');
+
+        // Fetch the root page to capture amz_web_sess cookie and extract webNonce.
+        var pageHtml = await http.GetStringAsync(trimmed + "/", ct);
+        var webNonce = ExtractAmzWebNonce(pageHtml)
+            ?? throw new InvalidOperationException("Could not extract window.__AMZ_WEB.n from amz.squid.wtf page");
 
         using var challengeResp = await http.GetAsync($"{trimmed}/api/captcha/challenge", ct);
         var challengeJson = await challengeResp.Content.ReadAsStringAsync(ct);
@@ -114,7 +125,7 @@ public class SquidWTFCaptchaSolver
         var solutionJson = JsonSerializer.Serialize(new { counter, derivedKey = derivedKeyHex, time = elapsedMs });
         var payloadJson = $"{{\"challenge\":{challengeJson.TrimEnd()},\"solution\":{solutionJson}}}";
         var payloadB64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(payloadJson));
-        var verifyBody = JsonSerializer.Serialize(new { payload = payloadB64 });
+        var verifyBody = JsonSerializer.Serialize(new { payload = payloadB64, webNonce });
 
         _logger.LogInformation("Amazon captcha: solved in {ElapsedMs}ms (counter={Counter}), verifying...", elapsedMs, counter);
         using var content = new StringContent(verifyBody, Encoding.UTF8, "application/json");
@@ -139,11 +150,16 @@ public class SquidWTFCaptchaSolver
         var token = tokenElement.GetString()
             ?? throw new InvalidOperationException("Amazon captcha token is null");
 
+        // Extract amz_web_sess value so callers can include it in subsequent API requests.
+        var sessionCookieValue = cookieContainer
+            .GetCookies(new Uri(trimmed))["amz_web_sess"]?.Value
+            ?? throw new InvalidOperationException("amz_web_sess cookie not found after captcha verify");
+
         _logger.LogInformation(
             "Amazon Music captcha solved in {ElapsedMs}ms (counter={Counter}), session valid ~{Minutes} min",
             elapsedMs, counter, (int)TokenValidity.TotalMinutes);
 
-        return token;
+        return (token, $"amz_web_sess={sessionCookieValue}");
     }
 
     private async Task<string> SolveAndVerifyAsync(string baseUrl, CancellationToken ct)
@@ -258,5 +274,14 @@ public class SquidWTFCaptchaSolver
 
         throw new InvalidOperationException(
             $"captcha solver exhausted {MaxSolverIterations} iterations without finding a match");
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex AmzWebNonceRegex =
+        new(@"__AMZ_WEB\s*=\s*\{""n""\s*:\s*""([^""]+)""", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string? ExtractAmzWebNonce(string html)
+    {
+        var m = AmzWebNonceRegex.Match(html);
+        return m.Success ? m.Groups[1].Value : null;
     }
 }

--- a/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFDownloadService.cs
@@ -226,8 +226,8 @@ public class SquidWTFDownloadService : BaseDownloadService
         for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
             bool forceRefresh = attempt > 1;
-            var token = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: forceRefresh, cancellationToken);
-            var trackResponse = await FetchAmazonTrackAsync(trackAsin, tier, country, token, cancellationToken);
+            var (token, sessionCookie) = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: forceRefresh, cancellationToken);
+            var trackResponse = await FetchAmazonTrackAsync(trackAsin, tier, country, token, sessionCookie, cancellationToken);
 
             if (trackResponse == null)
             {
@@ -250,7 +250,7 @@ public class SquidWTFDownloadService : BaseDownloadService
 
             try
             {
-                var downloadStream = await GetAmazonStreamAsync(streamUrl, token, cancellationToken);
+                var downloadStream = await GetAmazonStreamAsync(streamUrl, token, sessionCookie, cancellationToken);
                 var codec = (trackResponse.Stream.Codec ?? "").ToLowerInvariant();
                 var (extension, quality) = GetAmazonExtensionAndQuality(codec, tier);
                 return new DownloadResult(downloadStream, extension, quality, CencKey: cencKey);
@@ -265,15 +265,32 @@ public class SquidWTFDownloadService : BaseDownloadService
         throw new Exception($"Failed to download Amazon Music track {trackAsin} after {maxAttempts} attempts");
     }
 
+    private static void AddAmazonBrowserHeaders(HttpRequestMessage req, string sessionCookie, string token)
+    {
+        req.Headers.Add("Cookie", sessionCookie);
+        req.Headers.Add(AmazonCaptchaTokenHeader, token);
+        req.Headers.Add("Origin", AmazonBaseUrl);
+        req.Headers.Add("Referer", AmazonBaseUrl + "/");
+        req.Headers.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36");
+        req.Headers.Add("Accept", "*/*");
+        req.Headers.Add("Accept-Language", "en-US,en;q=0.9");
+        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+        req.Headers.Add("Sec-Fetch-Mode", "cors");
+        req.Headers.Add("Sec-Fetch-Dest", "empty");
+        req.Headers.Add("sec-ch-ua", "\"Chromium\";v=\"137\", \"Not/A)Brand\";v=\"24\", \"Google Chrome\";v=\"137\"");
+        req.Headers.Add("sec-ch-ua-mobile", "?0");
+        req.Headers.Add("sec-ch-ua-platform", "\"Linux\"");
+    }
+
     private async Task<AmazonMusicTrackResponse?> FetchAmazonTrackAsync(
-        string asin, string tier, string country, string token, CancellationToken cancellationToken)
+        string asin, string tier, string country, string token, string sessionCookie, CancellationToken cancellationToken)
     {
         try
         {
             var body = System.Text.Json.JsonSerializer.Serialize(new { asin, tier, country });
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{AmazonBaseUrl}/api/track");
             request.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
-            request.Headers.Add(AmazonCaptchaTokenHeader, token);
+            AddAmazonBrowserHeaders(request, sessionCookie, token);
 
             var response = await _httpClient.SendAsync(request, cancellationToken);
 
@@ -295,12 +312,10 @@ public class SquidWTFDownloadService : BaseDownloadService
         }
     }
 
-    private async Task<Stream> GetAmazonStreamAsync(string url, string token, CancellationToken cancellationToken)
+    private async Task<Stream> GetAmazonStreamAsync(string url, string token, string sessionCookie, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Add(AmazonCaptchaTokenHeader, token);
-        request.Headers.Add("User-Agent", "Mozilla/5.0");
-        request.Headers.Add("Accept", "*/*");
+        AddAmazonBrowserHeaders(request, sessionCookie, token);
 
         var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
@@ -308,11 +323,9 @@ public class SquidWTFDownloadService : BaseDownloadService
             response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
         {
             // One more attempt with a fresh token
-            var freshToken = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: true, cancellationToken);
+            var (freshToken, freshCookie) = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: true, cancellationToken);
             using var retryRequest = new HttpRequestMessage(HttpMethod.Get, url);
-            retryRequest.Headers.Add(AmazonCaptchaTokenHeader, freshToken);
-            retryRequest.Headers.Add("User-Agent", "Mozilla/5.0");
-            retryRequest.Headers.Add("Accept", "*/*");
+            AddAmazonBrowserHeaders(retryRequest, freshCookie, freshToken);
             response = await _httpClient.SendAsync(retryRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         }
 

--- a/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
+++ b/octo-fiesta/Services/SquidWTF/SquidWTFMetadataService.cs
@@ -568,16 +568,33 @@ public class SquidWTFMetadataService : IMusicMetadataService
         return album;
     }
 
+    private static void AddAmazonBrowserHeaders(HttpRequestMessage req, string sessionCookie, string token)
+    {
+        req.Headers.Add("Cookie", sessionCookie);
+        req.Headers.Add(AmazonCaptchaTokenHeader, token);
+        req.Headers.Add("Origin", AmazonBaseUrl);
+        req.Headers.Add("Referer", AmazonBaseUrl + "/");
+        req.Headers.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36");
+        req.Headers.Add("Accept", "*/*");
+        req.Headers.Add("Accept-Language", "en-US,en;q=0.9");
+        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+        req.Headers.Add("Sec-Fetch-Mode", "cors");
+        req.Headers.Add("Sec-Fetch-Dest", "empty");
+        req.Headers.Add("sec-ch-ua", "\"Chromium\";v=\"137\", \"Not/A)Brand\";v=\"24\", \"Google Chrome\";v=\"137\"");
+        req.Headers.Add("sec-ch-ua-mobile", "?0");
+        req.Headers.Add("sec-ch-ua-platform", "\"Linux\"");
+    }
+
     private async Task<string?> SendAmazonPostAsync(string path, object body)
     {
         try
         {
-            var token = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl);
+            var (token, sessionCookie) = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl);
             var json = JsonSerializer.Serialize(body);
 
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{AmazonBaseUrl}{path}");
             request.Content = new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json");
-            request.Headers.Add(AmazonCaptchaTokenHeader, token);
+            AddAmazonBrowserHeaders(request, sessionCookie, token);
 
             var response = await _httpClient.SendAsync(request);
 
@@ -585,10 +602,10 @@ public class SquidWTFMetadataService : IMusicMetadataService
                 response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
                 // Captcha token expired — refresh and retry once
-                token = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: true);
+                (token, sessionCookie) = await _captchaSolver.GetAmazonCaptchaTokenAsync(AmazonBaseUrl, forceRefresh: true);
                 using var retryRequest = new HttpRequestMessage(HttpMethod.Post, $"{AmazonBaseUrl}{path}");
                 retryRequest.Content = new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json");
-                retryRequest.Headers.Add(AmazonCaptchaTokenHeader, token);
+                AddAmazonBrowserHeaders(retryRequest, sessionCookie, token);
                 response = await _httpClient.SendAsync(retryRequest);
             }
 


### PR DESCRIPTION
amz.squid.wtf added three server-side checks that broke all requests:

- /api/captcha/verify now requires webNonce (window.__AMZ_WEB.n) extracted from the page HTML alongside the solved challenge payload
- amz_web_sess session cookie set on page load must travel with every subsequent request; use a dedicated HttpClient with CookieContainer for the captcha flow and forward the cookie to all API calls
- /api/search and other endpoints return 403 "only available through the web interface" without browser fingerprint headers; add Origin, Referer, User-Agent, Sec-Fetch-* and sec-ch-ua-* to all requests via AddAmazonBrowserHeaders helper in metadata and download services