### PR TITLE
fix: permanentize cached tracks on full album download

### DIFF
--- a/octo-fiesta/Services/Common/BaseDownloadService.cs
+++ b/octo-fiesta/Services/Common/BaseDownloadService.cs
@@ -963,6 +963,18 @@ public abstract class BaseDownloadService : IDownloadService
                     continue;
                 }
 
+                // Try to permanentize cached track BEFORE checking for completed downloads
+                // otherwise permanentization would be skipped as we already have a completed cache download
+                if (SubsonicSettings.StorageMode == StorageMode.Cache && forcePermanent)
+                {
+                    var permanentized = await PermanentizeCachedSongAsync(ProviderName, track.ExternalId!, cancellationToken);
+                    if (permanentized)
+                    {
+                        Logger.LogInformation("Permanentized cached track '{Title}' from album '{Album}'", track.Title, album.Title);
+                        continue;
+                    }
+                }
+
                 // Check if download is already in progress or recently completed
                 var songId = $"ext-{ProviderName}-{track.ExternalId}";
                 if (ActiveDownloads.TryGetValue(songId, out var activeDownload))


### PR DESCRIPTION
fixes #275

Simple fix: try to permanentize cached tracks on full album download if album download was triggered with `forcePermanent` in storage mode `Cache`.


There were no tests catching the issue, and I have no mental capacity for writing tests right now. We can do it in separate ticket I guess.