### PR TITLE
Add Wavio to the list of compatible clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See the [Supported Music Providers](https://github.com/V1ck3s/octo-fiesta/wiki/S
 | Platform | Clients |
 |----------|---------|
 | **Desktop** | [Aonsoku](https://github.com/victoralvesf/aonsoku), [Feishin](https://github.com/jeffvli/feishin), [Supersonic](https://github.com/dweymouth/supersonic), [Subplayer](https://github.com/peguerosdc/subplayer), [Aurial](https://github.com/shrimpza/aurial) |
-| **Android** | [Navic](https://github.com/paigely/Navic), [Tempus](https://github.com/eddyizm/tempus), [Substreamer](https://substreamerapp.com/), [Yuzic](https://github.com/eftpmc/yuzic) |
+| **Android** | [Navic](https://github.com/paigely/Navic), [Tempus](https://github.com/eddyizm/tempus), [Substreamer](https://substreamerapp.com/), [Yuzic](https://github.com/eftpmc/yuzic), [Wavio](https://github.com/Joel-Mercier/wavio) |
 | **iOS** | [Navic](https://github.com/paigely/Navic), [Narjo](https://www.reddit.com/r/NarjoApp/), [BeatsX](https://apps.apple.com/fr/app/beatsx/id6745130542), [Yuzic](https://github.com/eftpmc/yuzic) |
 
 See the [Compatible Clients](https://github.com/V1ck3s/octo-fiesta/wiki/Compatible-Clients) wiki page for details and incompatible clients.


### PR DESCRIPTION
Hi Wavio maintainer here. My app is coincidently compatible with your proxy server since it uses all the endpoints you proxy. Really cool project ! I didn't know it before a user of my app said it works with octo-fiesta. I tested it as well