### PR TITLE
fix(deezer): decrypt fallback/alternative tracks with the correct track id

### DIFF
--- a/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
+++ b/octo-fiesta/Services/Deezer/DeezerDownloadService.cs
@@ -131,8 +131,13 @@ public class DeezerDownloadService : BaseDownloadService
 
         // Decrypt
         // Streams are disposed at the calling side
+        // IMPORTANT: decrypt with downloadInfo.TrackId, not the original trackId.
+        // When a fallback/alternative track is used, its media is encrypted with the
+        // ALTERNATIVE id's Blowfish key; decrypting with the original id yields garbage
+        // (corrupt FLAC). GetTrackDownloadInfoAsync already resolves TrackId to the
+        // actual (alternative) id used for the media.
         var responseStream = await HttpResponseStream.CreateAsync(response, cancellationToken);
-        var downloadStream = new DeezerDecryptedStream(responseStream, trackId);
+        var downloadStream = new DeezerDecryptedStream(responseStream, downloadInfo.TrackId);
 
         return new DownloadResult(downloadStream, extension, downloadedQuality);
     }


### PR DESCRIPTION
## Problem
When a requested Deezer track isn't readable / returns no media, `GetTrackDownloadInfoInternalAsync` resolves an alternative (fallback) track and downloads *its* media. That media is Blowfish-encrypted with the **alternative** track id's key. But `DownloadTrackAsync` decrypted the stream with the original `trackId` method parameter, so every track that went through the fallback path produced an undecryptable, corrupt FLAC (TagLib then throws `FLAC stream not found at starting position` on metadata write).

## Root cause
The resolution already tracks this correctly — `GetTrackDownloadInfoInternalAsync` sets `TrackDownloadInfo.TrackId = decryptionTrackId` (the alternative id; note the existing `// Track ID used for decryption (may change if using alternative)` comment). Only the final decrypt call used the wrong variable.

## Fix
Decrypt with `downloadInfo.TrackId` instead of the original `trackId` (one line).

## Verification
A track that reproducibly downloaded as byte-identical garbage (no `fLaC` magic) via the fallback path now downloads as a valid FLAC and metadata writes succeed.