### PR TITLE
fix(subsonic): stream already-owned songs from the library instead of re-downloading

### DIFF
--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -157,8 +157,22 @@ public class SubsonicController : ControllerBase
             return await _proxyService.RelayStreamAsync(parameters, HttpContext.RequestAborted);
         }
 
-        // Always go through DownloadAndStreamAsync for external songs
-        // This ensures quality upgrade logic is applied
+        // If this external song is already in the local library, stream the owned
+        // copy from the Subsonic server instead of re-downloading from the provider.
+        // The mapping-based check in DownloadAndStreamAsync only knows Octo's own
+        // download path, which goes stale once an external tool (e.g. beets) moves
+        // the file into the managed library -> Octo would otherwise re-download an
+        // already-owned song on every play. GetLocalIdForExternalSongAsync resolves
+        // via a Subsonic search (title+artist / title+album), so it finds the moved
+        // or cross-release copy and we proxy that stream locally.
+        var localSongId = await _localLibraryService.GetLocalIdForExternalSongAsync(provider!, externalId!);
+        if (!string.IsNullOrEmpty(localSongId))
+        {
+            parameters["id"] = localSongId;
+            return await _proxyService.RelayStreamAsync(parameters, HttpContext.RequestAborted);
+        }
+
+        // Otherwise download from the provider and stream (quality upgrade logic applies)
         try
         {
             // Allow cancellation from both client disconnect and application shutdown


### PR DESCRIPTION
## Problem
`/rest/stream` always routes external songs through `DownloadAndStreamAsync`, whose only "already local" check is the download mapping's own `LocalPath`. When an external library manager (e.g. beets / Lidarr / a mover) relocates the downloaded file into the managed library, that mapping path goes stale (`File.Exists` == false), so Octo re-downloads a song the user already owns **on every play** — producing duplicate files and Navidrome `missing` ghosts for the moved copy.

## Fix
Before downloading, resolve the external id to a local Subsonic id via the existing `GetLocalIdForExternalSongAsync` (title+artist / title+album search — already used for star/scrobble/unstar). If the song is already in the library, rewrite `parameters["id"]` and proxy that stream (`RelayStreamAsync`) instead of downloading.

Bonus: this also covers cross-release cases — if the user owns the album version and plays the single/EP version (a *different* Deezer id), the owned copy is served rather than re-downloaded.

## Verification
Playing an external id whose song is already in the library now logs `Resolved local Subsonic ID <id> for external song deezer:<id>` and serves the local stream — no download, no duplicate.