### PR TITLE
feat(subsonic): merge provider catalogue into getTopSongs

### DIFF
--- a/octo-fiesta.Tests/SubsonicControllerGetTopSongsTests.cs
+++ b/octo-fiesta.Tests/SubsonicControllerGetTopSongsTests.cs
@@ -1,0 +1,315 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using octo_fiesta.Controllers;
+using octo_fiesta.Models.Domain;
+using octo_fiesta.Models.Settings;
+using octo_fiesta.Services;
+using octo_fiesta.Services.Local;
+using octo_fiesta.Services.Subsonic;
+using System.Net;
+using System.Text.Json;
+
+namespace octo_fiesta.Tests;
+
+/// <summary>
+/// getTopSongs used to fall through to the catch-all proxy, so Navidrome answered
+/// alone: it reads the Last.fm ranking then keeps only the titles already in the
+/// library. On a sparse library that returns one or two songs even when the
+/// provider has the whole catalogue. These tests pin the merge that fixes it.
+/// </summary>
+public class SubsonicControllerGetTopSongsTests
+{
+    private readonly Mock<IMusicMetadataService> _mockMetadataService;
+    private readonly Mock<ILocalLibraryService> _mockLocalLibraryService;
+    private readonly Mock<IDownloadService> _mockDownloadService;
+    private readonly Mock<ILogger<SubsonicController>> _mockLogger;
+    private readonly SubsonicRequestParser _requestParser;
+    private readonly SubsonicResponseBuilder _responseBuilder;
+    private readonly SubsonicModelMapper _modelMapper;
+    private readonly IOptions<SubsonicSettings> _settings;
+
+    public SubsonicControllerGetTopSongsTests()
+    {
+        _mockMetadataService = new Mock<IMusicMetadataService>();
+        _mockLocalLibraryService = new Mock<ILocalLibraryService>();
+        _mockDownloadService = new Mock<IDownloadService>();
+        _mockLogger = new Mock<ILogger<SubsonicController>>();
+
+        _requestParser = new SubsonicRequestParser();
+        _responseBuilder = new SubsonicResponseBuilder();
+        _modelMapper = new SubsonicModelMapper(
+            _responseBuilder,
+            new Mock<ILogger<SubsonicModelMapper>>().Object);
+
+        _settings = Options.Create(new SubsonicSettings
+        {
+            Url = "http://localhost:4533"
+        });
+    }
+
+    private SubsonicController CreateController(
+        Dictionary<string, string> queryParams,
+        HttpResponseMessage proxyResponse)
+    {
+        var mockHttpHandler = new Mock<HttpMessageHandler>();
+        mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(proxyResponse);
+
+        var httpClient = new HttpClient(mockHttpHandler.Object);
+        var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        var proxyService = new SubsonicProxyService(
+            mockHttpClientFactory.Object, _settings, httpContextAccessor);
+
+        var appLifetimeMock = new Mock<IHostApplicationLifetime>();
+        appLifetimeMock.SetupGet(x => x.ApplicationStopping).Returns(CancellationToken.None);
+
+        var controller = new SubsonicController(
+            _settings,
+            _mockMetadataService.Object,
+            _mockLocalLibraryService.Object,
+            _mockDownloadService.Object,
+            _requestParser,
+            _responseBuilder,
+            _modelMapper,
+            proxyService,
+            appLifetimeMock.Object,
+            _mockLogger.Object,
+            playlistSyncService: null);
+
+        var httpContext = new DefaultHttpContext();
+        var queryString = string.Join("&", queryParams.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        httpContext.Request.QueryString = new QueryString("?" + queryString);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return controller;
+    }
+
+    private static HttpResponseMessage NavidromeTopSongs(params (string Id, string Title)[] songs)
+    {
+        var entries = songs.Select(s =>
+            $"{{\"id\":\"{s.Id}\",\"title\":\"{s.Title}\",\"artist\":\"Serge Gainsbourg\"}}");
+        var body = "{\"subsonic-response\":{\"status\":\"ok\",\"version\":\"1.16.1\","
+                 + "\"topSongs\":{\"song\":[" + string.Join(",", entries) + "]}}}";
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body)
+        };
+        response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+        return response;
+    }
+
+    private static Song External(string title, string artist = "Serge Gainsbourg") => new()
+    {
+        Title = title,
+        Artist = artist,
+        Album = "Histoire de Melody Nelson",
+        ExternalProvider = "qobuz",
+        ExternalId = title.GetHashCode().ToString("x"),
+        IsLocal = false
+    };
+
+    private static List<string> TitlesOf(IActionResult result)
+    {
+        var json = Assert.IsType<JsonResult>(result);
+        using var doc = JsonSerializer.SerializeToDocument(json.Value!);
+        var songs = doc.RootElement
+            .GetProperty("subsonic-response")
+            .GetProperty("topSongs")
+            .GetProperty("song");
+
+        return songs.EnumerateArray()
+            .Select(s => s.GetProperty("title").GetString() ?? "")
+            .ToList();
+    }
+
+    [Fact]
+    public async Task GetTopSongs_AddsProviderSongsWhenLibraryIsSparse()
+    {
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<Song>
+            {
+                External("Ballade de Melody Nelson"),
+                External("Initials B.B."),
+                External("La javanaise")
+            });
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "count", "50" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs(("1", "Je Suis Venu Te Dire Que Je M'en Vais")));
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Equal(4, titles.Count);
+        Assert.Equal("Je Suis Venu Te Dire Que Je M'en Vais", titles[0]);
+        Assert.Contains("La javanaise", titles);
+    }
+
+    [Fact]
+    public async Task GetTopSongs_ExcludesSongsFromAnotherArtist()
+    {
+        // Searching the provider for "Serge Gainsbourg" also surfaces Charlotte
+        // Gainsbourg: the artist name has to be checked, not just the query.
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<Song>
+            {
+                External("Initials B.B."),
+                External("Deadly Valentine", artist: "Charlotte Gainsbourg")
+            });
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs());
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Contains("Initials B.B.", titles);
+        Assert.DoesNotContain("Deadly Valentine", titles);
+    }
+
+    [Fact]
+    public async Task GetTopSongs_KeepsCollaborationsWhereArtistLeadsTheCredit()
+    {
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<Song>
+            {
+                External("Je t'aime moi non plus", artist: "Serge Gainsbourg & Jane Birkin")
+            });
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs());
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Contains("Je t'aime moi non plus", titles);
+    }
+
+    [Fact]
+    public async Task GetTopSongs_DoesNotDuplicateATitleAlreadyInTheLibrary()
+    {
+        // Same song, different casing and a curly apostrophe: StringNormalizer
+        // is what keeps it from showing up twice.
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<Song>
+            {
+                External("je suis venu te dire que je m’en vais"),
+                External("La javanaise")
+            });
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs(("1", "Je Suis Venu Te Dire Que Je M'en Vais")));
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Equal(2, titles.Count);
+        Assert.Equal("Je Suis Venu Te Dire Que Je M'en Vais", titles[0]);
+        Assert.Contains("La javanaise", titles);
+    }
+
+    [Fact]
+    public async Task GetTopSongs_NeverReturnsMoreThanCount()
+    {
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<Song>
+            {
+                External("Initials B.B."),
+                External("La javanaise"),
+                External("La chanson de Prevert")
+            });
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "count", "2" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs(("1", "Je Suis Venu Te Dire Que Je M'en Vais")));
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Equal(2, titles.Count);
+        Assert.Equal("Je Suis Venu Te Dire Que Je M'en Vais", titles[0]);
+    }
+
+    [Fact]
+    public async Task GetTopSongs_WithoutArtistParameter_ReturnsSubsonicError10()
+    {
+        var controller = CreateController(
+            new Dictionary<string, string> { { "f", "json" } },
+            NavidromeTopSongs());
+
+        var result = await controller.GetTopSongs();
+
+        var json = Assert.IsType<JsonResult>(result);
+        using var doc = JsonSerializer.SerializeToDocument(json.Value!);
+        var error = doc.RootElement.GetProperty("subsonic-response").GetProperty("error");
+        Assert.Equal(10, error.GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task GetTopSongs_WhenProviderFails_StillReturnsTheLocalSongs()
+    {
+        _mockMetadataService
+            .Setup(x => x.SearchSongsAsync(It.IsAny<string>(), It.IsAny<int>()))
+            .ThrowsAsync(new HttpRequestException("provider down"));
+
+        var controller = CreateController(
+            new Dictionary<string, string>
+            {
+                { "artist", "Serge Gainsbourg" },
+                { "f", "json" }
+            },
+            NavidromeTopSongs(("1", "Je Suis Venu Te Dire Que Je M'en Vais")));
+
+        var titles = TitlesOf(await controller.GetTopSongs());
+
+        Assert.Single(titles);
+        Assert.Equal("Je Suis Venu Te Dire Que Je M'en Vais", titles[0]);
+    }
+}

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -598,6 +598,169 @@ public class SubsonicController : ControllerBase
     }
 
     /// <summary>
+    /// Merges the provider catalogue into an artist's top songs.
+    /// </summary>
+    /// <remarks>
+    /// Navidrome answers getTopSongs by intersecting the Last.fm ranking with the
+    /// local library, so a sparse library returns one or two titles even when the
+    /// provider carries the whole discography. Without this route the call fell
+    /// through to the catch-all proxy and external results never reached the client.
+    /// </remarks>
+    [HttpGet, HttpPost]
+    [Route("rest/getTopSongs")]
+    [Route("rest/getTopSongs.view")]
+    public async Task<IActionResult> GetTopSongs()
+    {
+        var parameters = await ExtractAllParameters();
+        var artistName = parameters.GetValueOrDefault("artist", "");
+        var format = parameters.GetValueOrDefault("f", "xml");
+
+        if (string.IsNullOrWhiteSpace(artistName))
+        {
+            return _responseBuilder.CreateError(format, 10, "Missing artist parameter");
+        }
+
+        var count = int.TryParse(parameters.GetValueOrDefault("count", "50"), out var parsedCount) && parsedCount > 0
+            ? parsedCount
+            : 50;
+
+        var navidromeTask = _proxyService.RelaySafeAsync("rest/getTopSongs", parameters);
+        var externalTask = SearchArtistCatalogSafeAsync(artistName, count);
+
+        await Task.WhenAll(navidromeTask, externalTask);
+
+        var navidromeResult = await navidromeTask;
+        var externalSongs = await externalTask;
+
+        if (!navidromeResult.Success || navidromeResult.Body == null)
+        {
+            return _responseBuilder.CreateResponse(format, "topSongs", new { });
+        }
+
+        // The merge below only builds JSON, so XML clients keep the untouched
+        // relay. Same contract as getArtist.
+        var isJson = format == "json" || navidromeResult.ContentType?.Contains("json") == true;
+        if (!isJson)
+        {
+            return File(navidromeResult.Body, navidromeResult.ContentType ?? "application/xml");
+        }
+
+        var mergedSongs = new List<object>();
+        var seenTitles = new HashSet<string>();
+
+        try
+        {
+            using var jsonDoc = JsonDocument.Parse(Encoding.UTF8.GetString(navidromeResult.Body));
+            if (jsonDoc.RootElement.TryGetProperty("subsonic-response", out var response) &&
+                response.TryGetProperty("topSongs", out var topSongs) &&
+                topSongs.TryGetProperty("song", out var songs) &&
+                songs.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var song in songs.EnumerateArray())
+                {
+                    mergedSongs.Add(_responseBuilder.ConvertSubsonicJsonElement(song, true));
+
+                    if (song.TryGetProperty("title", out var title))
+                    {
+                        seenTitles.Add(StringNormalizer.CreateComparisonKey(title.GetString()));
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            return File(navidromeResult.Body, navidromeResult.ContentType ?? "application/json");
+        }
+
+        foreach (var song in externalSongs)
+        {
+            if (mergedSongs.Count >= count)
+            {
+                break;
+            }
+
+            if (!IsCreditedTo(song.Artist, artistName))
+            {
+                continue;
+            }
+
+            if (!seenTitles.Add(StringNormalizer.CreateComparisonKey(song.Title)))
+            {
+                continue;
+            }
+
+            mergedSongs.Add(_responseBuilder.ConvertSongToJson(song));
+        }
+
+        if (mergedSongs.Count > count)
+        {
+            mergedSongs = mergedSongs.Take(count).ToList();
+        }
+
+        return _responseBuilder.CreateJsonResponse(new
+        {
+            status = "ok",
+            version = "1.16.1",
+            topSongs = new { song = mergedSongs }
+        });
+    }
+
+    /// <summary>
+    /// Separators that mark the end of a leading artist credit.
+    /// </summary>
+    private static readonly string[] CreditSeparators =
+        new[] { "&", ",", "/", "feat", "ft.", "with ", "and ", "x " };
+
+    /// <summary>
+    /// Looks the artist up on the provider. A provider outage must not cost the
+    /// user the local songs, so failures degrade to an empty list.
+    /// </summary>
+    private async Task<List<Song>> SearchArtistCatalogSafeAsync(string artistName, int count)
+    {
+        try
+        {
+            // Ask wide: the provider ranks by relevance to the query, which mixes in
+            // namesakes, and IsCreditedTo filters those out afterwards.
+            return await _metadataService.SearchSongsAsync(artistName, Math.Max(count, 20) * 2);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "getTopSongs: provider lookup failed for {Artist}", artistName);
+            return new List<Song>();
+        }
+    }
+
+    /// <summary>
+    /// True when the credit is the requested artist, alone or leading a
+    /// collaboration such as "Serge Gainsbourg &amp; Jane Birkin". Searching a
+    /// provider for one artist also surfaces namesakes - "Charlotte Gainsbourg"
+    /// for "Serge Gainsbourg" - so a plain substring test would let them through.
+    /// </summary>
+    private static bool IsCreditedTo(string? candidate, string artistName)
+    {
+        var candidateKey = StringNormalizer.CreateComparisonKey(candidate);
+        var artistKey = StringNormalizer.CreateComparisonKey(artistName);
+
+        if (candidateKey.Length == 0 || artistKey.Length == 0)
+        {
+            return false;
+        }
+
+        if (candidateKey == artistKey)
+        {
+            return true;
+        }
+
+        if (!candidateKey.StartsWith(artistKey, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var remainder = candidateKey[artistKey.Length..].TrimStart();
+        return CreditSeparators.Any(separator => remainder.StartsWith(separator, StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// Enriches local albums with external songs.
     /// </summary>
     [HttpGet, HttpPost]


### PR DESCRIPTION
## What

Adds a Subsonic **`getTopSongs`** route that merges the provider catalogue into an artist's top songs.

Today `getTopSongs` has no route, so it falls through to the catch-all proxy and the backing server answers alone. Navidrome builds that list by intersecting the Last.fm ranking with the **local** library, so a sparse library returns one or two titles even when the provider carries the whole discography.

Measured on a 3k-album library before this change: `getTopSongs?artist=Serge Gainsbourg` returned **1 song**. After: **10**.

## How

- Relays to the backing server and queries the provider **in parallel**, then merges: local songs keep their order and lead, provider songs fill the rest.
- **Deduplicated on the normalized title**, so a casing or curly-apostrophe variant doesn't show up twice.
- **Credit-based artist filter** rather than query-based: searching a provider for "Serge Gainsbourg" also returns Charlotte Gainsbourg. A collaboration where the artist leads the credit ("Serge Gainsbourg & Jane Birkin") is kept.
- Honours `count` (default 50) and returns Subsonic error 10 on a missing `artist`.

## Configuration

None. No new settings, no constructor signature changes.

## Compatibility

- A provider outage **degrades to the local songs** instead of failing the request (`SearchArtistCatalogSafeAsync` / `RelaySafeAsync`).
- Like `getArtist`, the merge only builds **JSON**; XML clients keep the untouched relay.
- Behaviour for clients that never call `getTopSongs` is unchanged.

## Tests

Adds `SubsonicControllerGetTopSongsTests` (315 lines) covering the merge order, title deduplication, the credit filter, the missing-artist error, provider-failure degradation and the XML passthrough. Full suite green (678 passed).

Running in production against Navidrome 0.63.2 with the Qobuz provider.
