### PR TITLE
fix(subsonic): drop irrelevant provider playlists from search3

### DIFF
--- a/octo-fiesta.Tests/PlaylistRelevanceFilterTests.cs
+++ b/octo-fiesta.Tests/PlaylistRelevanceFilterTests.cs
@@ -1,0 +1,146 @@
+using octo_fiesta.Models.Subsonic;
+using octo_fiesta.Services.Common;
+
+namespace octo_fiesta.Tests;
+
+/// <summary>
+/// Cases are seeded with real Qobuz playlist/search responses captured on
+/// 2026-09-07 against a live library, not with invented data.
+/// </summary>
+public class PlaylistRelevanceFilterTests
+{
+    private static ExternalPlaylist Playlist(string name, string? curator = "Qobuz France")
+        => new() { Id = "pl-qobuz-1", Name = name, CuratorName = curator, Provider = "qobuz" };
+
+    // "gainsbourg": every playlist Qobuz returned was genuinely about Gainsbourg.
+    [Fact]
+    public void Apply_WhenEveryPlaylistMatches_KeepsThemAll()
+    {
+        var playlists = new List<ExternalPlaylist>
+        {
+            Playlist("Serge Gainsbourg"),
+            Playlist("Gainsbourg, par les autres..."),
+            Playlist("Gainsbourg's Got Class(ique)", "What the France"),
+            Playlist("Charlotte Gainsbourg"),
+            Playlist("Les interprètes de Gainsbourg")
+        };
+
+        var result = PlaylistRelevanceFilter.Apply("gainsbourg", playlists);
+
+        Assert.Equal(5, result.Count);
+    }
+
+    // "keen v": Qobuz padded the response with five unrelated playlists.
+    [Fact]
+    public void Apply_WhenNothingMatches_DropsThePadding()
+    {
+        var playlists = new List<ExternalPlaylist>
+        {
+            Playlist("Protoje"),
+            Playlist("Kim Wilde"),
+            Playlist("HiFi ROSE", "HiFi ROSE"),
+            Playlist("Les classiques du Reggae"),
+            Playlist("Ella Fitzgerald")
+        };
+
+        var result = PlaylistRelevanceFilter.Apply("keen v", playlists);
+
+        Assert.Empty(result);
+    }
+
+    // "columbine": Qobuz matched loosely on "colum", which is not the query.
+    [Fact]
+    public void Apply_WithLooseProviderSubstringMatches_DropsThem()
+    {
+        var playlists = new List<ExternalPlaylist>
+        {
+            Playlist("Les classiques de Colombie"),
+            Playlist("100 ans de Columbia Pictures"),
+            Playlist("Columbia"),
+            Playlist("Colemine Records")
+        };
+
+        var result = PlaylistRelevanceFilter.Apply("columbine", playlists);
+
+        Assert.Empty(result);
+    }
+
+    // A multi-word query must match on ALL its words, or "Serge Gainsbourg"
+    // would keep the four chanson-francaise fillers Qobuz returned alongside it.
+    [Fact]
+    public void Apply_WithMultiWordQuery_RequiresEveryWord()
+    {
+        var playlists = new List<ExternalPlaylist>
+        {
+            Playlist("Serge Gainsbourg"),
+            Playlist("Hi-Res Masters : Classiques de la Chanson Française"),
+            Playlist("Chanson française - Années 80")
+        };
+
+        var result = PlaylistRelevanceFilter.Apply("Serge Gainsbourg", playlists);
+
+        Assert.Single(result);
+        Assert.Equal("Serge Gainsbourg", result[0].Name);
+    }
+
+    [Fact]
+    public void Apply_IgnoresCaseAndDiacritics()
+    {
+        var playlists = new List<ExternalPlaylist> { Playlist("Les interprètes de Gainsbourg") };
+
+        var result = PlaylistRelevanceFilter.Apply("INTERPRETES", playlists);
+
+        Assert.Single(result);
+    }
+
+    // The query may carry punctuation the playlist name spells differently.
+    [Fact]
+    public void Apply_IgnoresPunctuationOnBothSides()
+    {
+        var playlists = new List<ExternalPlaylist> { Playlist("Gainsbourg's Got Class(ique)", "What the France") };
+
+        var result = PlaylistRelevanceFilter.Apply("gainsbourg got class", playlists);
+
+        Assert.Single(result);
+    }
+
+    // Searching the curator is legitimate: it is how you find a label's shelf.
+    [Fact]
+    public void Apply_MatchesOnCuratorName()
+    {
+        var playlists = new List<ExternalPlaylist> { Playlist("Hi-Res Masters : Jazz", "What the France") };
+
+        var result = PlaylistRelevanceFilter.Apply("what the france", playlists);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Apply_WithBlankQuery_LeavesTheListUntouched()
+    {
+        var playlists = new List<ExternalPlaylist> { Playlist("Protoje") };
+
+        var result = PlaylistRelevanceFilter.Apply("   ", playlists);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Apply_WithNoPlaylists_ReturnsEmpty()
+    {
+        var result = PlaylistRelevanceFilter.Apply("gainsbourg", new List<ExternalPlaylist>());
+
+        Assert.Empty(result);
+    }
+
+    // A playlist with no curator must not blow up the haystack build.
+    [Fact]
+    public void Apply_WithNullCurator_StillMatchesOnName()
+    {
+        var playlists = new List<ExternalPlaylist> { Playlist("Serge Gainsbourg", null) };
+
+        var result = PlaylistRelevanceFilter.Apply("gainsbourg", playlists);
+
+        Assert.Single(result);
+    }
+}

--- a/octo-fiesta/Controllers/SubSonicController.cs
+++ b/octo-fiesta/Controllers/SubSonicController.cs
@@ -129,7 +129,9 @@ public class SubsonicController : ControllerBase
 
         var subsonicResult = await subsonicTask;
         var externalResult = await externalTask;
-        var playlistResult = await playlistTask;
+        // A provider that pads playlist search rather than returning nothing puts
+        // unrelated entries in the album section. Keep only what answers the query.
+        var playlistResult = PlaylistRelevanceFilter.Apply(cleanQuery, await playlistTask);
 
         return MergeSearchResults(subsonicResult, externalResult, playlistResult, format);
     }

--- a/octo-fiesta/Services/Common/PlaylistRelevanceFilter.cs
+++ b/octo-fiesta/Services/Common/PlaylistRelevanceFilter.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using System.Text;
+using octo_fiesta.Models.Subsonic;
+
+namespace octo_fiesta.Services.Common;
+
+/// <summary>
+/// Keeps only the external playlists that actually answer the query.
+///
+/// Provider playlist search never returns an empty list: with no real match,
+/// Qobuz pads its response with unrelated editorial playlists. Because search3
+/// has no playlist field, those are merged into the ALBUM section, so the
+/// padding reads as bogus albums sitting next to the user's real results.
+///
+/// The rule is deliberately blunt: every word of the query must appear in the
+/// playlist name or in its curator, ignoring case, accents and punctuation.
+/// Measured against live Qobuz responses on 2026-09-07, it keeps the five
+/// genuine "gainsbourg" playlists and drops the ten fillers returned for
+/// "keen v" and "columbine".
+/// </summary>
+public static class PlaylistRelevanceFilter
+{
+    /// <summary>
+    /// Returns the playlists relevant to <paramref name="query"/>. A blank query
+    /// carries nothing to judge relevance against, so the list is left untouched.
+    /// </summary>
+    public static List<ExternalPlaylist> Apply(string? query, IEnumerable<ExternalPlaylist>? playlists)
+    {
+        var candidates = playlists?.ToList() ?? new List<ExternalPlaylist>();
+        var terms = Tokenize(query);
+
+        return terms.Count == 0
+            ? candidates
+            : candidates.Where(p => Matches(terms, p)).ToList();
+    }
+
+    private static bool Matches(List<string> terms, ExternalPlaylist playlist)
+    {
+        var haystack = Flatten($"{playlist.Name} {playlist.CuratorName}");
+        return terms.All(term => haystack.Contains(term, StringComparison.Ordinal));
+    }
+
+    private static List<string> Tokenize(string? query)
+        => Flatten(query)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+    /// <summary>
+    /// Lowercases, strips diacritics, then turns every non-alphanumeric character
+    /// into a space, so "Gainsbourg's Got Class(ique)" and "gainsbourg got class"
+    /// compare on the same footing. Diacritics are folded here rather than through
+    /// StringNormalizer.CreateComparisonKey, which does not strip them.
+    /// </summary>
+    private static string Flatten(string? input)
+    {
+        var normalized = StringNormalizer
+            .NormalizeForComparison(input)
+            .Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(normalized.Length);
+
+        foreach (var c in normalized)
+        {
+            // FormD split accents into combining marks of their own; dropping them
+            // is what makes "INTERPRETES" match "interprètes".
+            if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
+            {
+                continue;
+            }
+
+            sb.Append(char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : ' ');
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Problem

Qobuz's `playlist/search` never returns an empty list. With no real match it pads the response with unrelated editorial playlists, and since `searchResult3` has no playlist field, those get merged into the **album** section — so the padding shows up as bogus albums next to the user's real results.

Measured against a live library, with `Subsonic__EnableExternalPlaylists=true`:

| Query | Playlists returned |
|---|---|
| `gainsbourg` | 5, all genuinely about Gainsbourg |
| `keen v` | 5: Protoje, Kim Wilde, HiFi ROSE, Les classiques du Reggae, Ella Fitzgerald |
| `columbine` | 5, matched loosely on "colum": Colombie, Columbia Pictures, Columbia, Colemine Records |

The `Math.Min(ac, 5)` cap keeps the noise bounded and puts it last, but it is still five wrong entries on every search that has no matching playlist. It is enough to make people turn the setting off entirely, which also costs them the playlists that *do* match.

## Change

`PlaylistRelevanceFilter` keeps only the playlists whose name or curator contains **every** word of the query, ignoring case, accents and punctuation. Applied at the single point where the results are awaited in `Search3`.

Requiring every word rather than a raw substring is what makes the multi-word case work: `Serge Gainsbourg` drops from 5 playlists to the 1 that is actually about him, because the four "chanson française" fillers do not contain "serge".

After the change, on the same library:

| Query | Before | After |
|---|---|---|
| `keen v` | 5 | **0** |
| `columbine` | 5 | **0** |
| `gainsbourg` | 5 | **5**, unchanged |
| `Serge Gainsbourg` | 5 | **1** |
| `Hi-Res Masters` | 5 | **5**, all genuinely "Hi-Res Masters" |

## Scope of the evidence, and a question for you

**Only Qobuz was measured.** I have credentials for that provider and no other, so the numbers above say nothing about Deezer, Tidal, Yandex or SquidWTF — and the filter runs for all of them.

The reasoning is that a provider whose playlist search is already precise loses nothing, since its results match the query by construction. The case that would cost something is a provider that returns a genuinely relevant playlist under a name that does not repeat the query — a "Rap FR" playlist for the query "rap français" would now be dropped.

If you would rather not change behaviour for providers nobody has measured, I am happy to put this behind a setting (`Subsonic__FilterExternalPlaylistsByRelevance`, defaulting either way) or to loosen the rule. Tell me which you prefer and I will push it.

## Notes

- Diacritics are folded inside the filter rather than through `StringNormalizer.CreateComparisonKey`, which does not strip them. No shared helper changes behaviour.
- A blank query leaves the list untouched, so nothing changes on the path where `Search3` relays without a query.
- 10 unit tests, seeded with the captured Qobuz responses above rather than invented data. Full suite green (681).